### PR TITLE
Add missing parameter to ECC-KEM

### DIFF
--- a/draft-ietf-openpgp-pqc.md
+++ b/draft-ietf-openpgp-pqc.md
@@ -693,7 +693,7 @@ defines the instances of the following operations:
 
 and
 
-    (eccKeyShare) <- ECC-KEM.Decaps(eccPublicKey, eccSecretKey, eccCipherText)
+    (eccKeyShare) <- ECC-KEM.Decaps(eccSecretKey, eccCipherText, eccPublicKey)
 
 To instantiate `ECC-KEM`, one must select a parameter set from
 {{tab-ecdh-cfrg-artifacts}}, {{tab-ecdh-nist-artifacts}}, or
@@ -993,7 +993,8 @@ scheme is as follows:
     encoded as `eccCipherText || mlkemCipherText || len(C) || C` as specified
     in {{ecc-mlkem-pkesk}}
 
- 7. Compute `(eccKeyShare) := ECC-KEM.Decaps(eccCipherText, eccSecretKey)`
+ 7. Compute `(eccKeyShare) := ECC-KEM.Decaps(eccCipherText, eccSecretKey,
+    eccPublicKey)`
 
  8. Compute `(mlkemKeyShare) := ML-KEM.Decaps(mlkemCipherText, mlkemSecretKey)`
 

--- a/draft-ietf-openpgp-pqc.md
+++ b/draft-ietf-openpgp-pqc.md
@@ -693,7 +693,7 @@ defines the instances of the following operations:
 
 and
 
-    (eccKeyShare) <- ECC-KEM.Decaps(eccSecretKey, eccCipherText)
+    (eccKeyShare) <- ECC-KEM.Decaps(eccPublicKey, eccSecretKey, eccCipherText)
 
 To instantiate `ECC-KEM`, one must select a parameter set from
 {{tab-ecdh-cfrg-artifacts}}, {{tab-ecdh-nist-artifacts}}, or


### PR DESCRIPTION
The `eccPublicKey` parameter is also used into the KDF, therefore required for the decaps