### PR TITLE
assign experimental/private codepoints; leave out MAY algorithms

### DIFF
--- a/draft-ietf-openpgp-pqc.md
+++ b/draft-ietf-openpgp-pqc.md
@@ -1143,8 +1143,8 @@ support the matching hash algorithm.
 {: title="Binding between ML-DSA and signature data digest" #tab-mldsa-hash}
 Algorithm ID reference | Hash function | Hash function ID reference
 ----------------------:| ------------- | --------------------------
-TBD                    | SHA3-256      | 12
-TBD                    | SHA3-512      | 14
+TBD (ML-DSA-65 IDs)    | SHA3-256      | 12
+TBD (ML-DSA-87 IDs)    | SHA3-512      | 14
 
 ### Key generation procedure {#ecc-mldsa-generation}
 

--- a/draft-ietf-openpgp-pqc.md
+++ b/draft-ietf-openpgp-pqc.md
@@ -507,28 +507,41 @@ fully specified by their algorithm ID and an additional parameter ID.
 For encryption, the following composite KEM schemes are specified:
 
 {: title="KEM algorithm specifications" #kem-alg-specs}
-ID | Algorithm                          | Requirement | Definition
---:| ---------------------------------- | ----------- | --------------------
-29 | ML-KEM-768  + X25519               | MUST        | {{ecc-mlkem}}
-30 | ML-KEM-1024 + X448                 | SHOULD      | {{ecc-mlkem}}
-31 | ML-KEM-768  + ECDH-NIST-P-256      | MAY         | {{ecc-mlkem}}
-32 | ML-KEM-1024 + ECDH-NIST-P-384      | MAY         | {{ecc-mlkem}}
-33 | ML-KEM-768  + ECDH-brainpoolP256r1 | MAY         | {{ecc-mlkem}}
-34 | ML-KEM-1024 + ECDH-brainpoolP384r1 | MAY         | {{ecc-mlkem}}
+ID                    | Algorithm                          | Requirement | Definition
+---------------------:| ---------------------------------- | ----------- | --------------------
+TBD (100 for testing) | ML-KEM-768  + X25519               | MUST        | {{ecc-mlkem}}
+TBD (101 for testing) | ML-KEM-1024 + X448                 | SHOULD      | {{ecc-mlkem}}
+TBD                   | ML-KEM-768  + ECDH-NIST-P-256      | MAY         | {{ecc-mlkem}}
+TBD                   | ML-KEM-1024 + ECDH-NIST-P-384      | MAY         | {{ecc-mlkem}}
+TBD                   | ML-KEM-768  + ECDH-brainpoolP256r1 | MAY         | {{ecc-mlkem}}
+TBD                   | ML-KEM-1024 + ECDH-brainpoolP384r1 | MAY         | {{ecc-mlkem}}
 
 For signatures, the following (composite) signature schemes are specified:
 
 {: title="Signature algorithm specifications" #sig-alg-specs}
-ID | Algorithm                          | Requirement | Definition
---:| ---------------------------------- | ----------- | --------------------
-35 | ML-DSA-65 + Ed25519                | MUST        | {{ecc-mldsa}}
-36 | ML-DSA-87 + Ed448                  | SHOULD      | {{ecc-mldsa}}
-37 | ML-DSA-65 + ECDSA-NIST-P-256       | MAY         | {{ecc-mldsa}}
-38 | ML-DSA-87 + ECDSA-NIST-P-384       | MAY         | {{ecc-mldsa}}
-39 | ML-DSA-65 + ECDSA-brainpoolP256r1  | MAY         | {{ecc-mldsa}}
-40 | ML-DSA-87 + ECDSA-brainpoolP384r1  | MAY         | {{ecc-mldsa}}
-41 | SLH-DSA-SHA2                       | SHOULD      | {{slhdsa}}
-42 | SLH-DSA-SHAKE                      | MAY         | {{slhdsa}}
+ID                    | Algorithm                          | Requirement | Definition
+---------------------:| ---------------------------------- | ----------- | --------------------
+TBD (102 for testing) | ML-DSA-65 + Ed25519                | MUST        | {{ecc-mldsa}}
+TBD (103 for testing) | ML-DSA-87 + Ed448                  | SHOULD      | {{ecc-mldsa}}
+TBD                   | ML-DSA-65 + ECDSA-NIST-P-256       | MAY         | {{ecc-mldsa}}
+TBD                   | ML-DSA-87 + ECDSA-NIST-P-384       | MAY         | {{ecc-mldsa}}
+TBD                   | ML-DSA-65 + ECDSA-brainpoolP256r1  | MAY         | {{ecc-mldsa}}
+TBD                   | ML-DSA-87 + ECDSA-brainpoolP384r1  | MAY         | {{ecc-mldsa}}
+TBD (104 for testing) | SLH-DSA-SHA2                       | SHOULD      | {{slhdsa}}
+TBD                   | SLH-DSA-SHAKE                      | MAY         | {{slhdsa}}
+
+### Experimental Codepoints for Interop Testing
+
+\[ Note: this section to be removed before publication \]
+
+Algorithms indicated as MAY are not assigned a codepoint in the current state of the draft
+since there are not enough private/experimental code points available
+to cover all newly introduced public-key algorithm identifiers.
+
+The use of private/experimental codepoints during development are intended to be used in non-released software only, for experimentation and interop testing purposes only.
+An OpenPGP implementation MUST NOT produce a formal release using these experimental codepoints.
+This draft will not be sent to IANA without every listed algorithm having a non-experimental codepoint.
+
 
 ## Parameter Specification
 
@@ -634,7 +647,7 @@ described in [RFC7748].
 {: title="Montgomery curves parameters and artifact lengths" #tab-ecdh-cfrg-artifacts}
 |                        | X25519                                     | X448                                       |
 |------------------------|--------------------------------------------|--------------------------------------------|
-| Algorithm ID reference | 29                                         | 30                                         |
+| Algorithm ID reference | TBD (100 for testing)                      | TBD (101 for testing)                      |
 | Field size             | 32 octets                                  | 56 octets                                  |
 | ECC-KEM                | x25519Kem ({{x25519-kem}})                 | x448Kem ({{x448-kem}})                     |
 | ECDH public key        | 32 octets [RFC7748]                        | 56 octets [RFC7748]                        |
@@ -647,7 +660,7 @@ described in [RFC7748].
 {: title="NIST curves parameters and artifact lengths" #tab-ecdh-nist-artifacts}
 |                        | NIST P-256                                             | NIST P-384                                             |
 |------------------------|--------------------------------------------------------|--------------------------------------------------------|
-| Algorithm ID reference | 31                                                     | 32                                                     |
+| Algorithm ID reference | TBD (ML-KEM-768 + ECDH-NIST-P-256)                     | TBD (ML-KEM-1024 + ECDH-NIST-P-384)                    |
 | Field size             | 32 octets                                              | 48 octets                                              |
 | ECC-KEM                | ecdhKem ({{ecdh-kem}})                                 | ecdhKem ({{ecdh-kem}})                                 |
 | ECDH public key        | 65 octets of SEC1-encoded public point                 | 97 octets of SEC1-encoded public point                 |
@@ -660,7 +673,7 @@ described in [RFC7748].
 {: title="Brainpool curves parameters and artifact lengths" #tab-ecdh-brainpool-artifacts}
 |                        | brainpoolP256r1                                        | brainpoolP384r1                                        |
 |------------------------|--------------------------------------------------------|--------------------------------------------------------|
-| Algorithm ID reference | 33                                                     | 34                                                     |
+| Algorithm ID reference | TBD (ML-KEM-768 + ECDH-brainpoolP256r1)                | TBD (ML-KEM-1024 + ECDH-brainpoolP384r1)               |
 | Field size             | 32 octets                                              | 48 octets                                              |
 | ECC-KEM                | ecdhKem ({{ecdh-kem}})                                 | ecdhKem ({{ecdh-kem}})                                 |
 | ECDH public key        | 65 octets of SEC1-encoded public point                 | 97 octets of SEC1-encoded public point                 |
@@ -792,8 +805,8 @@ defined in [FIPS-203].
 {: title="ML-KEM parameters artifact lengths in octets" #tab-mlkem-artifacts}
 Algorithm ID reference | ML-KEM      | Public key | Secret key | Ciphertext | Key share
 ----------------------:| ----------- | ---------- | ---------- | ---------- | ---------
-29, 31, 33             | ML-KEM-768  | 1184       | 2400       | 1088       | 32
-30, 32, 34             | ML-KEM-1024 | 1568       | 3168       | 1568       | 32
+TBD                    | ML-KEM-768  | 1184       | 2400       | 1088       | 32
+TBD                    | ML-KEM-1024 | 1568       | 3168       | 1568       | 32
 
 To instantiate `ML-KEM`, one must select a parameter set from the column
 "ML-KEM" of {{tab-mlkem-artifacts}}.
@@ -821,14 +834,14 @@ The procedure to perform `ML-KEM.Decaps()` is as follows:
 encryption schemes:
 
 {: title="ML-KEM + ECC composite schemes" #tab-mlkem-ecc-composite}
-Algorithm ID reference | ML-KEM       | ECC-KEM   | ECC-KEM curve
-----------------------:| ------------ | --------- | --------------
-29                     | ML-KEM-768   | x25519Kem | Curve25519
-30                     | ML-KEM-1024  | x448Kem   | Curve448
-31                     | ML-KEM-768   | ecdhKem   | NIST P-256
-32                     | ML-KEM-1024  | ecdhKem   | NIST P-384
-33                     | ML-KEM-768   | ecdhKem   | brainpoolP256r1
-34                     | ML-KEM-1024  | ecdhKem   | brainpoolP384r1
+Algorithm ID reference                   | ML-KEM       | ECC-KEM   | ECC-KEM curve
+----------------------------------------:| ------------ | --------- | --------------
+TBD (100 for testing)                    | ML-KEM-768   | x25519Kem | Curve25519
+TBD (101 for testing)                    | ML-KEM-1024  | x448Kem   | Curve448
+TBD (ML-KEM-768 + ECDH-NIST-P-256)       | ML-KEM-768   | ecdhKem   | NIST P-256
+TBD (ML-KEM-1024 + ECDH-NIST-P-384)      | ML-KEM-1024  | ecdhKem   | NIST P-384
+TBD (ML-KEM-768 + ECDH-brainpoolP256r1)  | ML-KEM-768   | ecdhKem   | brainpoolP256r1
+TBD (ML-KEM-1024 + ECDH-brainpoolP384r1) | ML-KEM-1024  | ecdhKem   | brainpoolP384r1
 
 The ML-KEM + ECC composite public-key encryption schemes are built according to
 the following principal design:
@@ -1060,8 +1073,8 @@ EdDSA parameters and artifact lengths:
 {: title="EdDSA parameters and artifact lengths in octets" #tab-eddsa-artifacts}
 Algorithm ID reference | Curve   | Field size | Public key | Secret key | Signature
 ----------------------:| ------- | ---------- | ---------- | ---------- | ---------
-35                     | Ed25519 | 32         | 32         | 32         | 64
-36                     | Ed448   | 57         | 57         | 57         | 114
+TBD (102 for testing)  | Ed25519 | 32         | 32         | 32         | 64
+TBD (103 for testing)  | Ed448   | 57         | 57         | 57         | 114
 
 ### ECDSA-Based signatures {#ecdsa-signature}
 
@@ -1083,12 +1096,12 @@ string of the specified size.
 The following table describes the ECDSA parameters and artifact lengths:
 
 {: title="ECDSA parameters and artifact lengths in octets" #tab-ecdsa-artifacts}
-Algorithm ID reference | Curve           | Field size | Public key | Secret key | Signature value R | Signature value S
-----------------------:| --------------- | ---------- | ---------- | ---------- | ----------------- | -----------------
-37                     | NIST P-256      | 32         | 65         | 32         | 32                | 32
-38                     | NIST P-384      | 48         | 97         | 48         | 48                | 48
-39                     | brainpoolP256r1 | 32         | 65         | 32         | 32                | 32
-40                     | brainpoolP384r1 | 48         | 97         | 48         | 48                | 48
+Algorithm ID reference                  | Curve           | Field size | Public key | Secret key | Signature value R | Signature value S
+---------------------------------------:| --------------- | ---------- | ---------- | ---------- | ----------------- | -----------------
+TBD (ML-DSA-65 + ECDSA-NIST-P-256)      | NIST P-256      | 32         | 65         | 32         | 32                | 32
+TBD (ML-DSA-87 + ECDSA-NIST-P-384)      | NIST P-384      | 48         | 97         | 48         | 48                | 48
+TBD (ML-DSA-65 + ECDSA-brainpoolP256r1) | brainpoolP256r1 | 32         | 65         | 32         | 32                | 32
+TBD (ML-DSA-87 + ECDSA-brainpoolP384r1) | brainpoolP384r1 | 48         | 97         | 48         | 48                | 48
 
 ### ML-DSA signatures {#mldsa-signature}
 
@@ -1111,8 +1124,8 @@ defined in [FIPS-204].
 {: title="ML-DSA parameters and artifact lengths in octets" #tab-mldsa-artifacts}
 Algorithm ID reference | ML-DSA    | Public key | Secret key | Signature value
 ----------------------:| --------- | -----------| ---------- | ---------------
-35, 37, 39             | ML-DSA-65 | 1952       | 4000       | 3293
-36, 38, 40             | ML-DSA-87 | 2592       | 4864       | 4595
+TBD                    | ML-DSA-65 | 1952       | 4000       | 3293
+TBD                    | ML-DSA-87 | 2592       | 4864       | 4595
 
 ## Composite Signature Schemes with ML-DSA {#ecc-mldsa}
 
@@ -1130,8 +1143,8 @@ support the matching hash algorithm.
 {: title="Binding between ML-DSA and signature data digest" #tab-mldsa-hash}
 Algorithm ID reference | Hash function | Hash function ID reference
 ----------------------:| ------------- | --------------------------
-35, 37, 39             | SHA3-256      | 12
-36, 38, 40             | SHA3-512      | 14
+TBD                    | SHA3-256      | 12
+TBD                    | SHA3-512      | 14
 
 ### Key generation procedure {#ecc-mldsa-generation}
 
@@ -1296,10 +1309,10 @@ also support the matching hash algorithm.
 {: title="Binding between SLH-DSA and signature data digest" #tab-slhdsa-hash}
 Algorithm ID reference | Parameter ID reference | Hash function | Hash function ID reference
 ----------------------:| ---------------------- | ------------- | --------------------------
-41                     | 1, 2                   | SHA-256       | 8
-41                     | 3, 4, 5, 6             | SHA-512       | 10
-42                     | 1, 2                   | SHA3-256      | 12
-42                     | 3, 4, 5, 6             | SHA3-512      | 14
+TBD (104 for testing)  | 1, 2                   | SHA-256       | 8
+TBD (104 for testing)  | 3, 4, 5, 6             | SHA-512       | 10
+TBD (SLH-DSA-SHAKE)    | 1, 2                   | SHA3-256      | 12
+TBD (SLH-DSA-SHAKE)    | 3, 4, 5, 6             | SHA3-512      | 14
 
 ### Key generation
 

--- a/draft-ietf-openpgp-pqc.md
+++ b/draft-ietf-openpgp-pqc.md
@@ -509,8 +509,8 @@ For encryption, the following composite KEM schemes are specified:
 {: title="KEM algorithm specifications" #kem-alg-specs}
 ID                    | Algorithm                          | Requirement | Definition
 ---------------------:| ---------------------------------- | ----------- | --------------------
-TBD (100 for testing) | ML-KEM-768  + X25519               | MUST        | {{ecc-mlkem}}
-TBD (101 for testing) | ML-KEM-1024 + X448                 | SHOULD      | {{ecc-mlkem}}
+TBD (105 for testing) | ML-KEM-768  + X25519               | MUST        | {{ecc-mlkem}}
+TBD (106 for testing) | ML-KEM-1024 + X448                 | SHOULD      | {{ecc-mlkem}}
 TBD                   | ML-KEM-768  + ECDH-NIST-P-256      | MAY         | {{ecc-mlkem}}
 TBD                   | ML-KEM-1024 + ECDH-NIST-P-384      | MAY         | {{ecc-mlkem}}
 TBD                   | ML-KEM-768  + ECDH-brainpoolP256r1 | MAY         | {{ecc-mlkem}}
@@ -521,13 +521,13 @@ For signatures, the following (composite) signature schemes are specified:
 {: title="Signature algorithm specifications" #sig-alg-specs}
 ID                    | Algorithm                          | Requirement | Definition
 ---------------------:| ---------------------------------- | ----------- | --------------------
-TBD (102 for testing) | ML-DSA-65 + Ed25519                | MUST        | {{ecc-mldsa}}
-TBD (103 for testing) | ML-DSA-87 + Ed448                  | SHOULD      | {{ecc-mldsa}}
+TBD (107 for testing) | ML-DSA-65 + Ed25519                | MUST        | {{ecc-mldsa}}
+TBD (108 for testing) | ML-DSA-87 + Ed448                  | SHOULD      | {{ecc-mldsa}}
 TBD                   | ML-DSA-65 + ECDSA-NIST-P-256       | MAY         | {{ecc-mldsa}}
 TBD                   | ML-DSA-87 + ECDSA-NIST-P-384       | MAY         | {{ecc-mldsa}}
 TBD                   | ML-DSA-65 + ECDSA-brainpoolP256r1  | MAY         | {{ecc-mldsa}}
 TBD                   | ML-DSA-87 + ECDSA-brainpoolP384r1  | MAY         | {{ecc-mldsa}}
-TBD (104 for testing) | SLH-DSA-SHA2                       | SHOULD      | {{slhdsa}}
+TBD (109 for testing) | SLH-DSA-SHA2                       | SHOULD      | {{slhdsa}}
 TBD                   | SLH-DSA-SHAKE                      | MAY         | {{slhdsa}}
 
 ### Experimental Codepoints for Interop Testing
@@ -647,7 +647,7 @@ described in [RFC7748].
 {: title="Montgomery curves parameters and artifact lengths" #tab-ecdh-cfrg-artifacts}
 |                        | X25519                                     | X448                                       |
 |------------------------|--------------------------------------------|--------------------------------------------|
-| Algorithm ID reference | TBD (100 for testing)                      | TBD (101 for testing)                      |
+| Algorithm ID reference | TBD (105 for testing)                      | TBD (106 for testing)                      |
 | Field size             | 32 octets                                  | 56 octets                                  |
 | ECC-KEM                | x25519Kem ({{x25519-kem}})                 | x448Kem ({{x448-kem}})                     |
 | ECDH public key        | 32 octets [RFC7748]                        | 56 octets [RFC7748]                        |
@@ -836,8 +836,8 @@ encryption schemes:
 {: title="ML-KEM + ECC composite schemes" #tab-mlkem-ecc-composite}
 Algorithm ID reference                   | ML-KEM       | ECC-KEM   | ECC-KEM curve
 ----------------------------------------:| ------------ | --------- | --------------
-TBD (100 for testing)                    | ML-KEM-768   | x25519Kem | Curve25519
-TBD (101 for testing)                    | ML-KEM-1024  | x448Kem   | Curve448
+TBD (105 for testing)                    | ML-KEM-768   | x25519Kem | Curve25519
+TBD (106 for testing)                    | ML-KEM-1024  | x448Kem   | Curve448
 TBD (ML-KEM-768 + ECDH-NIST-P-256)       | ML-KEM-768   | ecdhKem   | NIST P-256
 TBD (ML-KEM-1024 + ECDH-NIST-P-384)      | ML-KEM-1024  | ecdhKem   | NIST P-384
 TBD (ML-KEM-768 + ECDH-brainpoolP256r1)  | ML-KEM-768   | ecdhKem   | brainpoolP256r1
@@ -1073,8 +1073,8 @@ EdDSA parameters and artifact lengths:
 {: title="EdDSA parameters and artifact lengths in octets" #tab-eddsa-artifacts}
 Algorithm ID reference | Curve   | Field size | Public key | Secret key | Signature
 ----------------------:| ------- | ---------- | ---------- | ---------- | ---------
-TBD (102 for testing)  | Ed25519 | 32         | 32         | 32         | 64
-TBD (103 for testing)  | Ed448   | 57         | 57         | 57         | 114
+TBD (107 for testing)  | Ed25519 | 32         | 32         | 32         | 64
+TBD (108 for testing)  | Ed448   | 57         | 57         | 57         | 114
 
 ### ECDSA-Based signatures {#ecdsa-signature}
 
@@ -1309,8 +1309,8 @@ also support the matching hash algorithm.
 {: title="Binding between SLH-DSA and signature data digest" #tab-slhdsa-hash}
 Algorithm ID reference | Parameter ID reference | Hash function | Hash function ID reference
 ----------------------:| ---------------------- | ------------- | --------------------------
-TBD (104 for testing)  | 1, 2                   | SHA-256       | 8
-TBD (104 for testing)  | 3, 4, 5, 6             | SHA-512       | 10
+TBD (109 for testing)  | 1, 2                   | SHA-256       | 8
+TBD (109 for testing)  | 3, 4, 5, 6             | SHA-512       | 10
 TBD (SLH-DSA-SHAKE)    | 1, 2                   | SHA3-256      | 12
 TBD (SLH-DSA-SHAKE)    | 3, 4, 5, 6             | SHA3-512      | 14
 


### PR DESCRIPTION
fixes #83. this is an alternative to PR #86.

I only assign IDs to "MUST" and "SHOULD" algorithms.
In cases where a referenced ID is not assigned, I write `TBD (Full Algorithm Name)` to keep the reference in tact.

In cases where there are multiple IDs listed and the IDs are only there for convenience and the meaning of the table is still clear, I only write "TBD" to keep the draft more readable. For example in `Table 12: ML-DSA parameters and artifact lengths in octets`.