### PR TITLE
Align PKESK v3 ciphertext format with crypto-refresh's X25519 and X448

### DIFF
--- a/draft-ietf-openpgp-pqc.md
+++ b/draft-ietf-openpgp-pqc.md
@@ -1029,9 +1029,9 @@ The algorithm-specific fields consists of the output
  - A fixed-length octet string of the ML-KEM ciphertext, whose length depends
    on the algorithm ID as specified in {{tab-mlkem-artifacts}}.
 
- - Only in the case of a v3 PKESK packet: a one-octet symmetric algorithm identifier.
+ - A one-octet size of the following fields.
 
- - The one-octet size of the following field;
+ - Only in the case of a v3 PKESK packet: a one-octet symmetric algorithm identifier.
 
  - The wrapped session key represented as an octet string.
 


### PR DESCRIPTION
In [§5.1.6 of the crypto-refresh](https://www.ietf.org/archive/id/draft-ietf-openpgp-crypto-refresh-13.html#section-5.1.6), the order of fields in the ciphertext object is:

- 32 octets representing an ephemeral X25519 public key.
- A one-octet size of the following fields.
- The one-octet algorithm identifier, if it was passed (in the case of a v3 PKESK packet).
- The encrypted session key.

This change aligns the PQC wire format with the crypto-refresh wire format by swapping the length octet with the optional v3 PKESK algorithm identifier.

This has no impact on the v6 PKESK wire format, since the algorithm identifier field isn't present.

It is easier for implementers if they don't have to tweak these things between algorithms.