### PR TITLE
Fix ML-DSA private key size

### DIFF
--- a/draft-ietf-openpgp-pqc.md
+++ b/draft-ietf-openpgp-pqc.md
@@ -1138,8 +1138,8 @@ defined in [FIPS-204].
 {: title="ML-DSA parameters and artifact lengths in octets" #tab-mldsa-artifacts}
 Algorithm ID reference | ML-DSA    | Public key | Secret key | Signature value
 ----------------------:| --------- | -----------| ---------- | ---------------
-TBD                    | ML-DSA-65 | 1952       | 4000       | 3293
-TBD                    | ML-DSA-87 | 2592       | 4864       | 4595
+TBD                    | ML-DSA-65 | 1952       | 4032       | 3293
+TBD                    | ML-DSA-87 | 2592       | 4896       | 4595
 
 ## Composite Signature Schemes with ML-DSA {#ecc-mldsa}
 
@@ -1721,6 +1721,7 @@ Furthermore IANA will add the algorithm IDs defined in {{kem-alg-specs}} and
 - Added a recommendation to use `AES-256` when possible.
 - Swapped the optional v3 PKESK algorithm identifier with length octet
   in order to align with X25519 and X448.
+- Fixed ML-DSA private key size
 
 # Contributors
 


### PR DESCRIPTION
https://csrc.nist.gov/files/pubs/fips/204/ipd/docs/fips-204-initial-public-comments-2023.pdf

Based on the comment from Lauren Brandt on page 11, they got the sizes wrong in the IPD