### PR TITLE
reformatting of text: one sentence per line

### DIFF
--- a/draft-ietf-openpgp-pqc.md
+++ b/draft-ietf-openpgp-pqc.md
@@ -284,221 +284,147 @@ informative:
 
 --- abstract
 
-This document defines a post-quantum public-key algorithm extension for the
-OpenPGP protocol. Given the generally assumed threat of a cryptographically
-relevant quantum computer, this extension provides a basis for long-term secure
-OpenPGP signatures and ciphertexts. Specifically, it defines composite
-public-key encryption based on ML-KEM (formerly CRYSTALS-Kyber), composite
-public-key signatures based on ML-DSA (formerly CRYSTALS-Dilithium), both in
-combination with elliptic curve cryptography, and SLH-DSA-SHAKE (formerly SPHINCS+)
-as a standalone public key signature scheme.
+This document defines a post-quantum public-key algorithm extension for the OpenPGP protocol.
+Given the generally assumed threat of a cryptographically relevant quantum computer, this extension provides a basis for long-term secure OpenPGP signatures and ciphertexts.
+Specifically, it defines composite public-key encryption based on ML-KEM (formerly CRYSTALS-Kyber), composite public-key signatures based on ML-DSA (formerly CRYSTALS-Dilithium), both in combination with elliptic curve cryptography, and
+SLH-DSA-SHAKE (formerly SPHINCS+) as a standalone public key signature scheme.
 
 --- middle
 
 # Introduction
 
-The OpenPGP protocol supports various traditional public-key algorithms based
-on the factoring or discrete logarithm problem. As the security of algorithms
-based on these mathematical problems is endangered by the advent of quantum
-computers, there is a need to extend OpenPGP by algorithms that remain secure
-in the presence of quantum computers.
+The OpenPGP protocol supports various traditional public-key algorithms based on the factoring or discrete logarithm problem.
+As the security of algorithms based on these mathematical problems is endangered by the advent of quantum computers, there is a need to extend OpenPGP by algorithms that remain secure in the presence of quantum computers.
 
 Such cryptographic algorithms are referred to as post-quantum cryptography.
-The algorithms defined in this extension were chosen for standardization by the
-National Institute of Standards and Technology (NIST) in mid 2022
-{{NISTIR-8413}} as the result of the NIST Post-Quantum Cryptography
-Standardization process initiated in 2016 {{NIST-PQC}}. Namely, these are ML-KEM
-{{FIPS-203}} as a Key Encapsulation Mechanism (KEM), a KEM being a modern
-building block for public-key encryption, and ML-DSA {{FIPS-204}} as well as
-SLH-DSA-SHAKE {{FIPS-205}} as signature schemes.
+The algorithms defined in this extension were chosen for standardization by the National Institute of Standards and Technology (NIST) in mid 2022 {{NISTIR-8413}} as the result of the NIST Post-Quantum Cryptography Standardization process initiated in 2016 {{NIST-PQC}}.
+Namely, these are ML-KEM {{FIPS-203}} as a Key Encapsulation Mechanism (KEM), a KEM being a modern building block for public-key encryption, and ML-DSA {{FIPS-204}} as well as SLH-DSA-SHAKE {{FIPS-205}} as signature schemes.
 
-For the two ML-* schemes, this document follows the conservative strategy to
-deploy post-quantum in combination with traditional schemes such that the
-security is retained even if all schemes but one in the combination are broken.
-In contrast, the stateless hash-based signature scheme SLH-DSA-SHAKE is considered to
-be sufficiently well understood with respect to its security assumptions in
-order to be used standalone. To this end, this document specifies the following
-new set: SLH-DSA-SHAKE standalone and the two ML-* as composite with ECC-based KEM and
-digital signature schemes. Here, the term "composite" indicates that any data
-structure or algorithm pertaining to the combination of the two components
-appears as single data structure or algorithm from the protocol perspective.
+For the two ML-* schemes, this document follows the conservative strategy to deploy post-quantum in combination with traditional schemes such that the security is retained even if all schemes but one in the combination are broken.
+In contrast, the stateless hash-based signature scheme SLH-DSA-SHAKE is considered to be sufficiently well understood with respect to its security assumptions in order to be used standalone.
+To this end, this document specifies the following new set: SLH-DSA-SHAKE standalone and the two ML-* as composite with ECC-based KEM and digital signature schemes.
+Here, the term "composite" indicates that any data structure or algorithm pertaining to the combination of the two components appears as single data structure or algorithm from the protocol perspective.
 
-The document specifies the conventions for interoperability between compliant
-OpenPGP implementations that make use of this extension and the newly defined
-algorithms or algorithm combinations.
+The document specifies the conventions for interoperability between compliant OpenPGP implementations that make use of this extension and the newly defined algorithms or algorithm combinations.
 
 ## Conventions used in this Document
 
 ### Terminology for Multi-Algorithm Schemes
 
-The terminology in this document is oriented towards the definitions in
-[draft-driscoll-pqt-hybrid-terminology]. Specifically, the terms
-"multi-algorithm", "composite" and "non-composite" are used in correspondence
-with the definitions therein. The abbreviation "PQ" is used for post-quantum
-schemes. To denote the combination of post-quantum and traditional schemes, the
-abbreviation "PQ/T" is used. The short form "PQ(/T)" stands for PQ or PQ/T.
+The terminology in this document is oriented towards the definitions in [draft-driscoll-pqt-hybrid-terminology].
+Specifically, the terms "multi-algorithm", "composite" and "non-composite" are used in correspondence with the definitions therein.
+The abbreviation "PQ" is used for post-quantum schemes.
+To denote the combination of post-quantum and traditional schemes, the abbreviation "PQ/T" is used.
+The short form "PQ(/T)" stands for PQ or PQ/T.
 
 ## Post-Quantum Cryptography
 
-This section describes the individual post-quantum cryptographic schemes. All
-schemes listed here are believed to provide security in the presence of a
-cryptographically relevant quantum computer. However, the mathematical problems
-on which the two ML-* schemes and SLH-DSA-SHAKE are based, are fundamentally
-different, and accordingly the level of trust commonly placed in them as well
-as their performance characteristics vary.
+This section describes the individual post-quantum cryptographic schemes.
+All schemes listed here are believed to provide security in the presence of a cryptographically relevant quantum computer.
+However, the mathematical problems on which the two ML-* schemes and SLH-DSA-SHAKE are based, are fundamentally different, and accordingly the level of trust commonly placed in them as well as their performance characteristics vary.
 
-\[Note to the reader: This specification refers to the NIST PQC draft standards
-FIPS 203, FIPS 204, and FIPS 205 as if they were a final specification. This is
-a temporary solution until the final versions of these documents are available.
-The goal is to provide a sufficiently precise specification of the algorithms
-already at the draft stage of this specification, so that it is possible for
-implementers to create interoperable implementations. Furthermore, we want to
-point out that, depending on possible future changes to the draft standards by
-NIST, this specification may be updated as soon as corresponding information
-becomes available.\]
+\[Note to the reader: This specification refers to the NIST PQC draft standards FIPS 203, FIPS 204, and FIPS 205 as if they were a final specification.
+This is a temporary solution until the final versions of these documents are available.
+The goal is to provide a sufficiently precise specification of the algorithms already at the draft stage of this specification, so that it is possible for implementers to create interoperable implementations.
+Furthermore, we want to point out that, depending on possible future changes to the draft standards by NIST, this specification may be updated as soon as corresponding information becomes available.\]
 
 ### ML-KEM {#mlkem-intro}
 
-ML-KEM [FIPS-203] is based on the hardness of solving the learning-with-errors
-problem in module lattices (MLWE). The scheme is believed to provide security
-against cryptanalytic attacks by classical as well as quantum computers. This
-specification defines ML-KEM only in composite combination with ECC-based
-encryption schemes in order to provide a pre-quantum security fallback.
+ML-KEM [FIPS-203] is based on the hardness of solving the learning-with-errors problem in module lattices (MLWE).
+The scheme is believed to provide security against cryptanalytic attacks by classical as well as quantum computers.
+This specification defines ML-KEM only in composite combination with ECC-based encryption schemes in order to provide a pre-quantum security fallback.
 
 ### ML-DSA {#mldsa-intro}
 
-ML-DSA [FIPS-204] is a signature scheme that, like ML-KEM, is based on the
-hardness of solving the Learning With Errors problem and a variant of the Short
-Integer Solution problem in module lattices (MLWE and SelfTargetMSIS).
-Accordingly, this specification only defines ML-DSA in composite combination
-with ECC-based signature schemes.
+ML-DSA [FIPS-204] is a signature scheme that, like ML-KEM, is based on the hardness of solving the Learning With Errors problem and a variant of the Short Integer Solution problem in module lattices (MLWE and SelfTargetMSIS).
+Accordingly, this specification only defines ML-DSA in composite combination with ECC-based signature schemes.
 
 ### SLH-DSA-SHAKE
 
-SLH-DSA-SHAKE [FIPS-205] is a stateless hash-based signature scheme. Its security
-relies on the hardness of finding preimages for cryptographic hash functions.
+SLH-DSA-SHAKE [FIPS-205] is a stateless hash-based signature scheme.
+Its security relies on the hardness of finding preimages for cryptographic hash functions.
 This feature is generally considered to be a high security guarantee.
 Therefore, this specification defines SLH-DSA-SHAKE as a standalone signature scheme.
 
-In deployments the performance characteristics of SLH-DSA-SHAKE should be taken into
-account. We refer to {{performance-considerations}} for a discussion of the
-performance characteristics of this scheme.
+In deployments the performance characteristics of SLH-DSA-SHAKE should be taken into account.
+We refer to {{performance-considerations}} for a discussion of the performance characteristics of this scheme.
 
 ## Elliptic Curve Cryptography
 
-The ECC-based encryption is defined here as a KEM. This is in contrast to
-{{I-D.ietf-openpgp-crypto-refresh}} where the ECC-based encryption is defined
-as a public-key encryption scheme.
+The ECC-based encryption is defined here as a KEM.
+This is in contrast to {{I-D.ietf-openpgp-crypto-refresh}} where the ECC-based encryption is defined as a public-key encryption scheme.
 
-All elliptic curves for the use in the composite combinations are taken from
-{{I-D.ietf-openpgp-crypto-refresh}}. However, as explained in the following, in
-the case of Curve25519 encoding changes are applied to the new composite
-schemes.
+All elliptic curves for the use in the composite combinations are taken from {{I-D.ietf-openpgp-crypto-refresh}}.
+However, as explained in the following, in the case of Curve25519 encoding changes are applied to the new composite schemes.
 
 ### Curve25519 and Curve448
 
-Curve25519 and Curve448 are defined in [RFC7748] for use in a Diffie-Hellman
-key agreement scheme and defined in [RFC8032] for use in a digital signature
-scheme. For Curve25519 this specification adopts the encoding of objects as
-defined in [RFC7748].
+Curve25519 and Curve448 are defined in [RFC7748] for use in a Diffie-Hellman key agreement scheme and defined in [RFC8032] for use in a digital signature scheme.
+For Curve25519 this specification adopts the encoding of objects as defined in [RFC7748].
 
 ### Generic Prime Curves
 
-For interoperability this extension offers CRYSTALS-* in composite combinations
-with the NIST curves P-256, P-384 defined in {{SP800-186}} and the
-Brainpool curves brainpoolP256r1, brainpoolP384r1 defined in {{RFC5639}}.
+For interoperability this extension offers CRYSTALS-* in composite combinations with the NIST curves P-256, P-384 defined in {{SP800-186}} and the Brainpool curves brainpoolP256r1, brainpoolP384r1 defined in {{RFC5639}}.
 
 
 ## Standalone and Multi-Algorithm Schemes {#multi-algo-schemes}
 
-This section provides a categorization of the new algorithms and their
-combinations.
+This section provides a categorization of the new algorithms and their combinations.
 
 ### Standalone and Composite Multi-Algorithm Schemes {#composite-multi-alg}
 
-This specification introduces new cryptographic schemes, which can be
-categorized as follows:
+This specification introduces new cryptographic schemes, which can be categorized as follows:
 
- - PQ/T multi-algorithm public-key encryption, namely a composite combination
-   of ML-KEM with an ECC-based KEM,
+ - PQ/T multi-algorithm public-key encryption, namely a composite combination of ML-KEM with an ECC-based KEM,
 
- - PQ/T multi-algorithm digital signature, namely composite combinations of
-   ML-DSA with ECC-based signature schemes,
+ - PQ/T multi-algorithm digital signature, namely composite combinations of ML-DSA with ECC-based signature schemes,
 
- - PQ digital signature, namely SLH-DSA-SHAKE as a standalone cryptographic
-   algorithm.
+ - PQ digital signature, namely SLH-DSA-SHAKE as a standalone cryptographic algorithm.
 
-For each of the composite schemes, this specification mandates that the
-recipient has to successfully perform the cryptographic algorithms for each of
-the component schemes used in a cryptographic message, in order for the
-message to be deciphered and considered as valid. This means that all component
-signatures must be verified successfully in order to achieve a successful
-verification of the composite signature. In the case of the composite
-public-key decryption, each of the component KEM decapsulation operations must
-succeed.
+For each of the composite schemes, this specification mandates that the recipient has to successfully perform the cryptographic algorithms for each of the component schemes used in a cryptographic message, in order for the message to be deciphered and considered as valid.
+This means that all component signatures must be verified successfully in order to achieve a successful verification of the composite signature.
+In the case of the composite public-key decryption, each of the component KEM decapsulation operations must succeed.
 
 ### Non-Composite Algorithm Combinations {#non-composite-multi-alg}
 
-As the OpenPGP protocol [I-D.ietf-openpgp-crypto-refresh] allows for multiple
-signatures to be applied to a single message, it is also possible to realize
-non-composite combinations of signatures. Furthermore, multiple OpenPGP
-signatures may be combined on the application layer. These latter two cases
-realize non-composite combinations of signatures. {{multiple-signatures}}
-specifies how implementations should handle the verification of such
-combinations of signatures.
+As the OpenPGP protocol [I-D.ietf-openpgp-crypto-refresh] allows for multiple signatures to be applied to a single message, it is also possible to realize non-composite combinations of signatures.
+Furthermore, multiple OpenPGP signatures may be combined on the application layer.
+These latter two cases realize non-composite combinations of signatures.
+{{multiple-signatures}} specifies how implementations should handle the verification of such combinations of signatures.
 
-Furthermore, the OpenPGP protocol also allows for parallel encryption to
-different keys held by the same recipient. Accordingly, if the sender makes use
-of this feature and sends an encrypted message with multiple PKESK packages for
-different encryption keys held by the same recipient, a non-composite
-multi-algorithm public-key encryption is realized where the recipient has to
-decrypt only one of the PKESK packages in order to decrypt the message. See
-{{no-pq-t-parallel-encryption}} for restrictions on parallel encryption
-mandated by this specification.
+Furthermore, the OpenPGP protocol also allows for parallel encryption to different keys held by the same recipient.
+Accordingly, if the sender makes use of this feature and sends an encrypted message with multiple PKESK packages for different encryption keys held by the same recipient, a non-composite multi-algorithm public-key encryption is realized where the recipient has to decrypt only one of the PKESK packages in order to decrypt the message.
+See {{no-pq-t-parallel-encryption}} for restrictions on parallel encryption mandated by this specification.
 
 # Preliminaries
 
-This section provides some preliminaries for the definitions in the subsequent
-sections.
+This section provides some preliminaries for the definitions in the subsequent sections.
 
 ## Elliptic curves
 
 ### SEC1 EC Point Wire Format {#sec1-format}
 
-Elliptic curve points of the generic prime curves are encoded using the SEC1
-(uncompressed) format as the following octet string:
+Elliptic curve points of the generic prime curves are encoded using the SEC1 (uncompressed) format as the following octet string:
 
     B = 04 || X || Y
 
-where `X` and `Y` are coordinates of the elliptic curve point `P = (X, Y)`, and
-each coordinate is encoded in the big-endian format and zero-padded to the
-adjusted underlying field size. The adjusted underlying field size is the
-underlying field size rounded up to the nearest 8-bit boundary, as noted in the
-"Field size" column in {{tab-ecdh-nist-artifacts}},
-{{tab-ecdh-brainpool-artifacts}}, or {{tab-ecdsa-artifacts}}. This encoding is
-compatible with the definition given in [SEC1].
+where `X` and `Y` are coordinates of the elliptic curve point `P = (X, Y)`, and each coordinate is encoded in the big-endian format and zero-padded to the adjusted underlying field size.
+The adjusted underlying field size is the underlying field size rounded up to the nearest 8-bit boundary, as noted in the "Field size" column in {{tab-ecdh-nist-artifacts}}, {{tab-ecdh-brainpool-artifacts}}, or {{tab-ecdsa-artifacts}}.
+This encoding is compatible with the definition given in [SEC1].
 
 ### Measures to Ensure Secure Implementations
 
-In the following measures are described that ensure secure implementations
-according to existing best practices and standards defining the operations of
-Elliptic Curve Cryptography.
+In the following measures are described that ensure secure implementations according to existing best practices and standards defining the operations of Elliptic Curve Cryptography.
 
-Even though the zero point, also called the point at infinity, may occur as a
-result of arithmetic operations on points of an elliptic curve, it MUST NOT
-appear in any ECC data structure defined in this document.
+Even though the zero point, also called the point at infinity, may occur as a result of arithmetic operations on points of an elliptic curve, it MUST NOT appear in any ECC data structure defined in this document.
 
-Furthermore, when performing the explicitly listed operations in
-{{x25519-kem}}, {{x448-kem}} or {{ecdh-kem}} it is REQUIRED to follow the
-specification and security advisory mandated from the respective elliptic curve
-specification.
+Furthermore, when performing the explicitly listed operations in {{x25519-kem}}, {{x448-kem}} or {{ecdh-kem}} it is REQUIRED to follow the specification and security advisory mandated from the respective elliptic curve specification.
 
 
 # Supported Public Key Algorithms
 
-This section specifies the composite ML-KEM + ECC and ML-DSA + ECC schemes as
-well as the standalone SLH-DSA-SHAKE signature scheme. All of these schemes are
-fully specified via their algorithm ID, i.e., they are not parametrized.
+This section specifies the composite ML-KEM + ECC and ML-DSA + ECC schemes as well as the standalone SLH-DSA-SHAKE signature scheme.
+All of these schemes are fully specified via their algorithm ID, i.e., they are not parametrized.
 
 ## Algorithm Specifications
 
@@ -533,9 +459,7 @@ TBD                   | SLH-DSA-SHAKE-256s                 | MAY         | {{slh
 
 \[ Note: this section to be removed before publication \]
 
-Algorithms indicated as MAY are not assigned a codepoint in the current state of the draft
-since there are not enough private/experimental code points available
-to cover all newly introduced public-key algorithm identifiers.
+Algorithms indicated as MAY are not assigned a codepoint in the current state of the draft since there are not enough private/experimental code points available to cover all newly introduced public-key algorithm identifiers.
 
 The use of private/experimental codepoints during development are intended to be used in non-released software only, for experimentation and interop testing purposes only.
 An OpenPGP implementation MUST NOT produce a formal release using these experimental codepoints.
@@ -545,46 +469,30 @@ This draft will not be sent to IANA without every listed algorithm having a non-
 
 ## Composite KEMs
 
-The ML-KEM + ECC public-key encryption involves both the ML-KEM and an
-ECC-based KEM in an a priori non-separable manner. This is achieved via KEM
-combination, i.e. both key encapsulations/decapsulations are performed in
-parallel, and the resulting key shares are fed into a key combiner to produce a
-single shared secret for message encryption.
+The ML-KEM + ECC public-key encryption involves both the ML-KEM and an ECC-based KEM in an a priori non-separable manner.
+This is achieved via KEM combination, i.e. both key encapsulations/decapsulations are performed in parallel, and the resulting key shares are fed into a key combiner to produce a single shared secret for message encryption.
 
 ## Parallel Public-Key Encryption {#no-pq-t-parallel-encryption}
 
-As explained in {{non-composite-multi-alg}}, the OpenPGP protocol inherently
-supports parallel encryption to different keys of the same recipient.
-Implementations MUST NOT encrypt a message with a purely traditional public-key
-encryption key of a recipient if it is encrypted with a PQ/T key of the same
-recipient.
+As explained in {{non-composite-multi-alg}}, the OpenPGP protocol inherently supports parallel encryption to different keys of the same recipient.
+Implementations MUST NOT encrypt a message with a purely traditional public-key encryption key of a recipient if it is encrypted with a PQ/T key of the same recipient.
 
 ## Composite Signatures
 
-The ML-DSA + ECC signature consists of independent ML-DSA and ECC signatures,
-and an implementation MUST successfully validate both signatures to state that
-the ML-DSA + ECC signature is valid.
+The ML-DSA + ECC signature consists of independent ML-DSA and ECC signatures, and an implementation MUST successfully validate both signatures to state that the ML-DSA + ECC signature is valid.
 
 ## Multiple Signatures {#multiple-signatures}
 
-The OpenPGP message format allows multiple signatures of a message, i.e. the
-attachment of multiple signature packets.
+The OpenPGP message format allows multiple signatures of a message, i.e. the attachment of multiple signature packets.
 
-An implementation MAY sign a message with a traditional key and a PQ(/T) key
-from the same sender. This ensures backwards compatibility due to
-{{I-D.ietf-openpgp-crypto-refresh}} Section 5.2.5, since a legacy
-implementation without PQ(/T) support can fall back on the traditional
-signature.
+An implementation MAY sign a message with a traditional key and a PQ(/T) key from the same sender.
+This ensures backwards compatibility due to {{I-D.ietf-openpgp-crypto-refresh}} Section 5.2.5, since a legacy implementation without PQ(/T) support can fall back on the traditional signature.
 
-Newer implementations with PQ(/T) support MAY ignore the traditional
-signature(s) during validation.
+Newer implementations with PQ(/T) support MAY ignore the traditional signature(s) during validation.
 
-Implementations SHOULD consider the message correctly signed if at least one of
-the non-ignored signatures validates successfully.
+Implementations SHOULD consider the message correctly signed if at least one of the non-ignored signatures validates successfully.
 
-\[Note to the reader: The last requirement, that one valid signature is
-sufficient to identify a message as correctly signed, is an interpretation of
-{{I-D.ietf-openpgp-crypto-refresh}} Section 5.2.5.\]
+\[Note to the reader: The last requirement, that one valid signature is sufficient to identify a message as correctly signed, is an interpretation of {{I-D.ietf-openpgp-crypto-refresh}} Section 5.2.5.\]
 
 # Composite KEM schemes
 
@@ -592,13 +500,10 @@ sufficient to identify a message as correctly signed, is an interpretation of
 
 ### ECC-Based KEMs {#ecc-kem}
 
-In this section we define the encryption, decryption, and data formats for the
-ECDH component of the composite algorithms.
+In this section we define the encryption, decryption, and data formats for the ECDH component of the composite algorithms.
 
-{{tab-ecdh-cfrg-artifacts}}, {{tab-ecdh-nist-artifacts}}, and
-{{tab-ecdh-brainpool-artifacts}} describe the ECC-KEM parameters and artifact
-lengths. The artifacts in {{tab-ecdh-cfrg-artifacts}} follow the encodings
-described in [RFC7748].
+{{tab-ecdh-cfrg-artifacts}}, {{tab-ecdh-nist-artifacts}}, and {{tab-ecdh-brainpool-artifacts}} describe the ECC-KEM parameters and artifact lengths.
+The artifacts in {{tab-ecdh-cfrg-artifacts}} follow the encodings described in [RFC7748].
 
 {: title="Montgomery curves parameters and artifact lengths" #tab-ecdh-cfrg-artifacts}
 |                        | X25519                                     | X448                                       |
@@ -641,9 +546,8 @@ described in [RFC7748].
 
 The SEC1 format for point encoding is defined in {{sec1-format}}.
 
-The various procedures to perform the operations of an ECC-based KEM are
-defined in the following subsections. Specifically, each of these subsections
-defines the instances of the following operations:
+The various procedures to perform the operations of an ECC-based KEM are defined in the following subsections.
+Specifically, each of these subsections defines the instances of the following operations:
 
     (eccCipherText, eccKeyShare) <- ECC-KEM.Encaps(eccPublicKey)
 
@@ -651,25 +555,19 @@ and
 
     (eccKeyShare) <- ECC-KEM.Decaps(eccSecretKey, eccCipherText, eccPublicKey)
 
-To instantiate `ECC-KEM`, one must select a parameter set from
-{{tab-ecdh-cfrg-artifacts}}, {{tab-ecdh-nist-artifacts}}, or
-{{tab-ecdh-brainpool-artifacts}}.
+To instantiate `ECC-KEM`, one must select a parameter set from {{tab-ecdh-cfrg-artifacts}}, {{tab-ecdh-nist-artifacts}}, or {{tab-ecdh-brainpool-artifacts}}.
 
 #### X25519-KEM {#x25519-kem}
 
-The encapsulation and decapsulation operations of `x25519kem` are described
-using the function `X25519()` and encodings defined in [RFC7748]. The
-`eccSecretKey` is denoted as `r`, the `eccPublicKey` as `R`, they are subject
-to the equation `R = X25519(r, U(P))`. Here, `U(P)` denotes the u-coordinate of
-the base point of Curve25519.
+The encapsulation and decapsulation operations of `x25519kem` are described using the function `X25519()` and encodings defined in [RFC7748].
+The `eccSecretKey` is denoted as `r`, the `eccPublicKey` as `R`, they are subject to the equation `R = X25519(r, U(P))`.
+Here, `U(P)` denotes the u-coordinate of the base point of Curve25519.
 
 The operation `x25519Kem.Encaps()` is defined as follows:
 
- 1. Generate an ephemeral key pair {`v`, `V`} via `V = X25519(v,U(P))` where `v`
-    is a randomly generated octet string with a length of 32 octets
+ 1. Generate an ephemeral key pair {`v`, `V`} via `V = X25519(v,U(P))` where `v` is a randomly generated octet string with a length of 32 octets
 
- 2. Compute the shared coordinate `X = X25519(v, R)` where `R` is the recipient's public key
-    `eccPublicKey`
+ 2. Compute the shared coordinate `X = X25519(v, R)` where `R` is the recipient's public key `eccPublicKey`
 
  3. Set the output `eccCipherText` to `V`
 
@@ -677,26 +575,21 @@ The operation `x25519Kem.Encaps()` is defined as follows:
 
 The operation `x25519Kem.Decaps()` is defined as follows:
 
- 1. Compute the shared coordinate `X = X25519(r, V)`, where `r` is the
-    `eccSecretKey` and `V` is the `eccCipherText`
+ 1. Compute the shared coordinate `X = X25519(r, V)`, where `r` is the `eccSecretKey` and `V` is the `eccCipherText`
 
  2. Set the output `eccKeyShare` to `SHA3-256(X || eccCipherText || eccPublicKey)`
 
 #### X448-KEM {#x448-kem}
 
-The encapsulation and decapsulation operations of `x448kem` are described using
-the function `X448()` and encodings defined in [RFC7748]. The `eccSecretKey`
-is denoted as `r`, the `eccPublicKey` as `R`, they are subject to the equation
-`R = X25519(r, U(P))`. Here, `U(P)` denotes the u-coordinate of the base point
-of Curve448.
+The encapsulation and decapsulation operations of `x448kem` are described using the function `X448()` and encodings defined in [RFC7748].
+The `eccSecretKey` is denoted as `r`, the `eccPublicKey` as `R`, they are subject to the equation `R = X25519(r, U(P))`.
+Here, `U(P)` denotes the u-coordinate of the base point of Curve448.
 
 The operation `x448.Encaps()` is defined as follows:
 
- 1. Generate an ephemeral key pair {`v`, `V`} via `V = X448(v,U(P))` where `v`
-    is a randomly generated octet string with a length of 56 octets
+ 1. Generate an ephemeral key pair {`v`, `V`} via `V = X448(v,U(P))` where `v` is a randomly generated octet string with a length of 56 octets
 
- 2. Compute the shared coordinate `X = X448(v, R)` where `R` is the recipient's public key
-    `eccPublicKey`
+ 2. Compute the shared coordinate `X = X448(v, R)` where `R` is the recipient's public key `eccPublicKey`
 
  3. Set the output `eccCipherText` to `V`
 
@@ -704,8 +597,7 @@ The operation `x448.Encaps()` is defined as follows:
 
 The operation `x448Kem.Decaps()` is defined as follows:
 
- 1. Compute the shared coordinate `X = X448(r, V)`, where `r` is the
-    `eccSecretKey` and `V` is the `eccCipherText`
+ 1. Compute the shared coordinate `X = X448(r, V)`, where `r` is the `eccSecretKey` and `V` is the `eccCipherText`
 
  2. Set the output `eccKeyShare` to `SHA3-512(X || eccCipherText || eccPublicKey)`
 
@@ -713,33 +605,23 @@ The operation `x448Kem.Decaps()` is defined as follows:
 
 The operation `ecdhKem.Encaps()` is defined as follows:
 
- 1. Generate an ephemeral key pair {`v`, `V=vG`} as defined in {{SP800-186}} or
-    {{RFC5639}} where `v` is a random scalar with `0 < v < n`, `n` being the
-    base point order of the elliptic curve domain parameters
+ 1. Generate an ephemeral key pair {`v`, `V=vG`} as defined in {{SP800-186}} or {{RFC5639}} where `v` is a random scalar with `0 < v < n`, `n` being the base point order of the elliptic curve domain parameters
 
- 2. Compute the shared point `S = vR`, where `R` is the component public key
-    `eccPublicKey`, according to {{SP800-186}} or {{RFC5639}}
+ 2. Compute the shared point `S = vR`, where `R` is the component public key `eccPublicKey`, according to {{SP800-186}} or {{RFC5639}}
 
- 3. Extract the `X` coordinate from the SEC1 encoded point `S = 04 || X || Y`
-    as defined in section {{sec1-format}}
+ 3. Extract the `X` coordinate from the SEC1 encoded point `S = 04 || X || Y` as defined in section {{sec1-format}}
 
  4. Set the output `eccCipherText` to the SEC1 encoding of `V`
 
- 5. Set the output `eccKeyShare` to `Hash(X || eccCipherText || eccPublicKey)`,
-    with `Hash` chosen according to {{tab-ecdh-nist-artifacts}} or
-    {{tab-ecdh-brainpool-artifacts}}
+ 5. Set the output `eccKeyShare` to `Hash(X || eccCipherText || eccPublicKey)`, with `Hash` chosen according to {{tab-ecdh-nist-artifacts}} or {{tab-ecdh-brainpool-artifacts}}
 
 The operation `ecdhKem.Decaps()` is defined as follows:
 
- 1. Compute the shared Point `S` as `rV`, where `r` is the `eccSecretKey` and
-    `V` is the `eccCipherText`, according to {{SP800-186}} or {{RFC5639}}
+ 1. Compute the shared Point `S` as `rV`, where `r` is the `eccSecretKey` and `V` is the `eccCipherText`, according to {{SP800-186}} or {{RFC5639}}
 
- 2. Extract the `X` coordinate from the SEC1 encoded point `S = 04 || X || Y`
-    as defined in section {{sec1-format}}
+ 2. Extract the `X` coordinate from the SEC1 encoded point `S = 04 || X || Y` as defined in section {{sec1-format}}
 
- 3. Set the output `eccKeyShare` to `Hash(X || eccCipherText || eccPublicKey)`,
-    with `Hash` chosen according to {{tab-ecdh-nist-artifacts}} or
-    {{tab-ecdh-brainpool-artifacts}}
+ 3. Set the output `eccKeyShare` to `Hash(X || eccCipherText || eccPublicKey)`, with `Hash` chosen according to {{tab-ecdh-nist-artifacts}} or {{tab-ecdh-brainpool-artifacts}}
 
 ### ML-KEM {#mlkem-ops}
 
@@ -751,13 +633,11 @@ and
 
     (mlkemKeyShare) <- ML-KEM.Decaps(mlkemCipherText, mlkemSecretKey)
 
-The above are the operations `ML-KEM.Encaps` and `ML-KEM.Decaps` defined in
-[FIPS-203]. Note that `mlkemPublicKey` is the encapsulation and
-`mlkemSecretKey` is the decapsulation key.
+The above are the operations `ML-KEM.Encaps` and `ML-KEM.Decaps` defined in [FIPS-203].
+Note that `mlkemPublicKey` is the encapsulation and `mlkemSecretKey` is the decapsulation key.
 
-ML-KEM has the parametrization with the corresponding artifact lengths in
-octets as given in {{tab-mlkem-artifacts}}. All artifacts are encoded as
-defined in [FIPS-203].
+ML-KEM has the parametrization with the corresponding artifact lengths in octets as given in {{tab-mlkem-artifacts}}.
+All artifacts are encoded as defined in [FIPS-203].
 
 {: title="ML-KEM parameters artifact lengths in octets" #tab-mlkem-artifacts}
 Algorithm ID reference | ML-KEM      | Public key | Secret key | Ciphertext | Key share
@@ -765,8 +645,7 @@ Algorithm ID reference | ML-KEM      | Public key | Secret key | Ciphertext | Ke
 TBD                    | ML-KEM-768  | 1184       | 2400       | 1088       | 32
 TBD                    | ML-KEM-1024 | 1568       | 3168       | 1568       | 32
 
-To instantiate `ML-KEM`, one must select a parameter set from the column
-"ML-KEM" of {{tab-mlkem-artifacts}}.
+To instantiate `ML-KEM`, one must select a parameter set from the column "ML-KEM" of {{tab-mlkem-artifacts}}.
 
 The procedure to perform `ML-KEM.Encaps()` is as follows:
 
@@ -784,8 +663,7 @@ The procedure to perform `ML-KEM.Decaps()` is as follows:
 
 ## Composite Encryption Schemes with ML-KEM {#ecc-mlkem}
 
-{{kem-alg-specs}} specifies the following ML-KEM + ECC composite public-key
-encryption schemes:
+{{kem-alg-specs}} specifies the following ML-KEM + ECC composite public-key encryption schemes:
 
 {: title="ML-KEM + ECC composite schemes" #tab-mlkem-ecc-composite}
 Algorithm ID reference                   | ML-KEM       | ECC-KEM   | ECC-KEM curve
@@ -797,31 +675,21 @@ TBD (ML-KEM-1024 + ECDH-NIST-P-384)      | ML-KEM-1024  | ecdhKem   | NIST P-384
 TBD (ML-KEM-768 + ECDH-brainpoolP256r1)  | ML-KEM-768   | ecdhKem   | brainpoolP256r1
 TBD (ML-KEM-1024 + ECDH-brainpoolP384r1) | ML-KEM-1024  | ecdhKem   | brainpoolP384r1
 
-The ML-KEM + ECC composite public-key encryption schemes are built according to
-the following principal design:
+The ML-KEM + ECC composite public-key encryption schemes are built according to the following principal design:
 
- - The ML-KEM encapsulation algorithm is invoked to create a ML-KEM ciphertext
-   together with a ML-KEM symmetric key share.
+ - The ML-KEM encapsulation algorithm is invoked to create a ML-KEM ciphertext together with a ML-KEM symmetric key share.
 
- - The encapsulation algorithm of an ECC-based KEM, namely one out of
-   X25519-KEM, X448-KEM, or ECDH-KEM is invoked to create an ECC ciphertext
-   together with an ECC symmetric key share.
+ - The encapsulation algorithm of an ECC-based KEM, namely one out of X25519-KEM, X448-KEM, or ECDH-KEM is invoked to create an ECC ciphertext together with an ECC symmetric key share.
 
- - A Key-Encryption-Key (KEK) is computed as the output of a key combiner that
-   receives as input both of the above created symmetric key shares and the
-   protocol binding information.
+ - A Key-Encryption-Key (KEK) is computed as the output of a key combiner that receives as input both of the above created symmetric key shares and the protocol binding information.
 
- - The session key for content encryption is then wrapped as described in
-   {{RFC3394}} using AES-256 as algorithm and the KEK as key.
+ - The session key for content encryption is then wrapped as described in {{RFC3394}} using AES-256 as algorithm and the KEK as key.
 
- - The PKESK package's algorithm-specific parts are made up of the ML-KEM
-   ciphertext, the ECC ciphertext, and the wrapped session key.
+ - The PKESK package's algorithm-specific parts are made up of the ML-KEM ciphertext, the ECC ciphertext, and the wrapped session key.
 
 ### Fixed information {#kem-fixed-info}
 
-For the composite KEM schemes defined in {{kem-alg-specs}} the following
-procedure, justified in {{sec-fixed-info}}, MUST be used to derive a string to
-use as binding between the KEK and the communication parties.
+For the composite KEM schemes defined in {{kem-alg-specs}} the following procedure, justified in {{sec-fixed-info}}, MUST be used to derive a string to use as binding between the KEK and the communication parties.
 
     //   Input:
     //   algID     - the algorithm ID encoded as octet
@@ -830,12 +698,9 @@ use as binding between the KEK and the communication parties.
 
 ### Key combiner {#kem-key-combiner}
 
-For the composite KEM schemes defined in {{kem-alg-specs}} the following
-procedure MUST be used to compute the KEK that wraps a session key. The
-construction is a one-step key derivation function compliant to {{SP800-56C}}
-Section 4, based on KMAC256 {{SP800-185}}. It is given by the following
-algorithm, which computes the key encryption key `KEK` that is used to wrap,
-i.e., encrypt, the session key.
+For the composite KEM schemes defined in {{kem-alg-specs}} the following procedure MUST be used to compute the KEK that wraps a session key.
+The construction is a one-step key derivation function compliant to {{SP800-56C}} Section 4, based on KMAC256 {{SP800-185}}.
+It is given by the following algorithm, which computes the key encryption key `KEK` that is used to wrap, i.e., encrypt, the session key.
 
     //   multiKeyCombine(eccKeyShare, eccCipherText,
     //                   mlkemKeyShare, mlkemCipherText,
@@ -862,17 +727,12 @@ i.e., encrypt, the session key.
     KEK = KMAC256(domSeparation, encData, oBits, customizationString)
     return KEK
 
-Here, the parameters to KMAC256 appear in the order as specified in
-{{SP800-186}}, Section 4, i.e., the key `K`, main input data `X`, requested
-output length `L`, and optional customization string `S` in that order.
+Here, the parameters to KMAC256 appear in the order as specified in {{SP800-186}}, Section 4, i.e., the key `K`, main input data `X`, requested output length `L`, and optional customization string `S` in that order.
 
-Note that the values `eccKeyShare` defined in {{ecc-kem}} and `mlkemKeyShare`
-defined in {{mlkem-ops}} already use the relative ciphertext in the
-derivation. The ciphertext is by design included again in the key combiner to
-provide a robust security proof.
+Note that the values `eccKeyShare` defined in {{ecc-kem}} and `mlkemKeyShare` defined in {{mlkem-ops}} already use the relative ciphertext in the derivation.
+The ciphertext is by design included again in the key combiner to provide a robust security proof.
 
-The value of `domSeparation` is the UTF-8 encoding of the string
-"OpenPGPCompositeKeyDerivationFunction" and MUST be the following octet sequence:
+The value of `domSeparation` is the UTF-8 encoding of the string "OpenPGPCompositeKeyDerivationFunction" and MUST be the following octet sequence:
 
     domSeparation := 4F 70 65 6E 50 47 50 43 6F 6D 70 6F 73 69 74 65
                      4B 65 79 44 65 72 69 76 61 74 69 6F 6E 46 75 6E
@@ -884,38 +744,27 @@ The value of `counter` MUST be set to the following octet sequence:
 
 The value of `fixedInfo` MUST be set according to {{kem-fixed-info}}.
 
-The value of `customizationString` is the UTF-8 encoding of the string "KDF"
-and MUST be set to the following octet sequence:
+The value of `customizationString` is the UTF-8 encoding of the string "KDF" and MUST be set to the following octet sequence:
 
     customizationString := 4B 44 46
 
 ### Key generation procedure {#ecc-mlkem-generation}
 
-The implementation MUST independently generate the ML-KEM and the ECC component
-keys. ML-KEM key generation follows the specification [FIPS-203] and the
-artifacts are encoded as fixed-length octet strings as defined in
-{{mlkem-ops}}. For ECC this is done following the relative specification in
-{{RFC7748}}, {{SP800-186}}, or {{RFC5639}}, and encoding the outputs as
-fixed-length octet strings in the format specified in
-{{tab-ecdh-cfrg-artifacts}}, {{tab-ecdh-nist-artifacts}}, or
-{{tab-ecdh-brainpool-artifacts}}.
+The implementation MUST independently generate the ML-KEM and the ECC component keys.
+ML-KEM key generation follows the specification [FIPS-203] and the artifacts are encoded as fixed-length octet strings as defined in {{mlkem-ops}}.
+For ECC this is done following the relative specification in {{RFC7748}}, {{SP800-186}}, or {{RFC5639}}, and encoding the outputs as fixed-length octet strings in the format specified in {{tab-ecdh-cfrg-artifacts}}, {{tab-ecdh-nist-artifacts}}, or {{tab-ecdh-brainpool-artifacts}}.
 
 ### Encryption procedure {#ecc-mlkem-encryption}
 
-The procedure to perform public-key encryption with a ML-KEM + ECC composite
-scheme is as follows:
+The procedure to perform public-key encryption with a ML-KEM + ECC composite scheme is as follows:
 
- 1. Take the recipient's authenticated public-key packet `pkComposite` and
-   `sessionKey` as input
+ 1. Take the recipient's authenticated public-key packet `pkComposite` and `sessionKey` as input
 
  2. Parse the algorithm ID from `pkComposite`
 
- 3. Extract the `eccPublicKey` and `mlkemPublicKey` component from the
-    algorithm specific data encoded in `pkComposite` with the format specified
-    in {{mlkem-ecc-key}}.
+ 3. Extract the `eccPublicKey` and `mlkemPublicKey` component from the algorithm specific data encoded in `pkComposite` with the format specified in {{mlkem-ecc-key}}.
 
- 4. Instantiate the ECC-KEM and the ML-KEM depending on the algorithm ID
-    according to {{tab-mlkem-ecc-composite}}
+ 4. Instantiate the ECC-KEM and the ML-KEM depending on the algorithm ID according to {{tab-mlkem-ecc-composite}}
 
  5. Compute `(eccCipherText, eccKeyShare) := ECC-KEM.Encaps(eccPublicKey)`
 
@@ -923,53 +772,37 @@ scheme is as follows:
 
  7. Compute `fixedInfo` as specified in {{kem-fixed-info}}
 
- 8. Compute `KEK := multiKeyCombine(eccKeyShare, eccCipherText, mlkemKeyShare,
-    mlkemCipherText, fixedInfo, oBits=256)` as defined in {{kem-key-combiner}}
+ 8. Compute `KEK := multiKeyCombine(eccKeyShare, eccCipherText, mlkemKeyShare, mlkemCipherText, fixedInfo, oBits=256)` as defined in {{kem-key-combiner}}
 
- 9. Compute `C := AESKeyWrap(KEK, sessionKey)` with AES-256 as per {{RFC3394}}
-    that includes a 64 bit integrity check
+ 9. Compute `C := AESKeyWrap(KEK, sessionKey)` with AES-256 as per {{RFC3394}} that includes a 64 bit integrity check
 
- 10. Output the algorithm specific part of the PKESK as
-     `eccCipherText || mlkemCipherText (|| symAlgId) || len(C) || C`, where
-     both `symAlgId` and `len(C)` are single octet fields and `symAlgId`
-     denotes the symmetric algorithm ID used and is present only for a v3 PKESK
+ 10. Output the algorithm specific part of the PKESK as `eccCipherText || mlkemCipherText (|| symAlgId) || len(C) || C`, where both `symAlgId` and `len(C)` are single octet fields and `symAlgId` denotes the symmetric algorithm ID used and is present only for a v3 PKESK
 
 ### Decryption procedure
 
-The procedure to perform public-key decryption with a ML-KEM + ECC composite
-scheme is as follows:
+The procedure to perform public-key decryption with a ML-KEM + ECC composite scheme is as follows:
 
  1. Take the matching PKESK and own secret key packet as input
 
- 2. From the PKESK extract the algorithm ID and the `encryptedKey`, i.e., the
-    wrapped session key
+ 2. From the PKESK extract the algorithm ID and the `encryptedKey`, i.e., the wrapped session key
 
  3. Check that the own and the extracted algorithm ID match
 
- 4. Parse the `eccSecretKey` and `mlkemSecretKey` from the algorithm specific
-    data of the own secret key encoded in the format specified in
-    {{mlkem-ecc-key}}
+ 4. Parse the `eccSecretKey` and `mlkemSecretKey` from the algorithm specific data of the own secret key encoded in the format specified in {{mlkem-ecc-key}}
 
- 5. Instantiate the ECC-KEM and the ML-KEM depending on the algorithm ID
-    according to {{tab-mlkem-ecc-composite}}
+ 5. Instantiate the ECC-KEM and the ML-KEM depending on the algorithm ID according to {{tab-mlkem-ecc-composite}}
 
- 6. Parse `eccCipherText`, `mlkemCipherText`, and `C` from `encryptedKey`
-    encoded as `eccCipherText || mlkemCipherText (|| symAlgId) || len(C) || C` as specified
-    in {{ecc-mlkem-pkesk}}, where `symAlgId` is present only in the case of a v3
-    PKESK.
+ 6. Parse `eccCipherText`, `mlkemCipherText`, and `C` from `encryptedKey` encoded as `eccCipherText || mlkemCipherText (|| symAlgId) || len(C) || C` as specified in {{ecc-mlkem-pkesk}}, where `symAlgId` is present only in the case of a v3 PKESK.
 
- 7. Compute `(eccKeyShare) := ECC-KEM.Decaps(eccCipherText, eccSecretKey,
-    eccPublicKey)`
+ 7. Compute `(eccKeyShare) := ECC-KEM.Decaps(eccCipherText, eccSecretKey, eccPublicKey)`
 
  8. Compute `(mlkemKeyShare) := ML-KEM.Decaps(mlkemCipherText, mlkemSecretKey)`
 
  9. Compute `fixedInfo` as specified in {{kem-fixed-info}}
 
- 10. Compute `KEK := multiKeyCombine(eccKeyShare, eccCipherText, mlkemKeyShare,
-     mlkemCipherText, fixedInfo, oBits=256)` as defined in {{kem-key-combiner}}
+ 10. Compute `KEK := multiKeyCombine(eccKeyShare, eccCipherText, mlkemKeyShare, mlkemCipherText, fixedInfo, oBits=256)` as defined in {{kem-key-combiner}}
 
- 11. Compute `sessionKey := AESKeyUnwrap(KEK, C)`  with AES-256 as per
-     {{RFC3394}}, aborting if the 64 bit integrity check fails
+ 11. Compute `sessionKey := AESKeyUnwrap(KEK, C)`  with AES-256 as per {{RFC3394}}, aborting if the 64 bit integrity check fails
 
  12. Output `sessionKey`
 
@@ -977,14 +810,11 @@ scheme is as follows:
 
 ### Public-Key Encrypted Session Key Packets (Tag 1) {#ecc-mlkem-pkesk}
 
-The algorithm-specific fields consists of the output
-     of the encryption procedure described in {{ecc-mlkem-encryption}}:
+The algorithm-specific fields consists of the output of the encryption procedure described in {{ecc-mlkem-encryption}}:
 
- - A fixed-length octet string representing an ECC ephemeral public key in the
-   format associated with the curve as specified in {{ecc-kem}}.
+ - A fixed-length octet string representing an ECC ephemeral public key in the format associated with the curve as specified in {{ecc-kem}}.
 
- - A fixed-length octet string of the ML-KEM ciphertext, whose length depends
-   on the algorithm ID as specified in {{tab-mlkem-artifacts}}.
+ - A fixed-length octet string of the ML-KEM ciphertext, whose length depends on the algorithm ID as specified in {{tab-mlkem-artifacts}}.
 
  - A one-octet size of the following fields.
 
@@ -992,36 +822,26 @@ The algorithm-specific fields consists of the output
 
  - The wrapped session key represented as an octet string.
 
-Note that like in the case of the algorithms X25519 and X448 specified in
-{{I-D.ietf-openpgp-crypto-refresh}}, for the ML-KEM composite schemes, in the
-case of a v3 PKESK packet, the symmetric algorithm identifier is not encrypted.
-Instead, it is placed in plaintext after the `mlkemCipherText` and before the
-length octet preceding the wrapped session key.  In the case of v3 PKESK packets
-for ML-KEM composite schemes, the symmetric algorithm used MUST be AES-128,
-AES-192 or AES-256 (algorithm ID 7, 8 or 9).
+Note that like in the case of the algorithms X25519 and X448 specified in {{I-D.ietf-openpgp-crypto-refresh}}, for the ML-KEM composite schemes, in the case of a v3 PKESK packet, the symmetric algorithm identifier is not encrypted.
+Instead, it is placed in plaintext after the `mlkemCipherText` and before the length octet preceding the wrapped session key.
+In the case of v3 PKESK packets for ML-KEM composite schemes, the symmetric algorithm used MUST be AES-128, AES-192 or AES-256 (algorithm ID 7, 8 or 9).
 
-In the case of a v3 PKESK, a receiving implementation MUST check if the length of
-the unwrapped symmetric key matches the symmetric algorithm identifier, and abort
-if this is not the case.
+In the case of a v3 PKESK, a receiving implementation MUST check if the length of the unwrapped symmetric key matches the symmetric algorithm identifier, and abort if this is not the case.
 
 
 ### Key Material Packets {#mlkem-ecc-key}
 
 The algorithm-specific public key is this series of values:
 
- - A fixed-length octet string representing an EC point public key, in the
-   point format associated with the curve specified in {{ecc-kem}}.
+ - A fixed-length octet string representing an EC point public key, in the point format associated with the curve specified in {{ecc-kem}}.
 
- - A fixed-length octet string containing the ML-KEM public key, whose
-   length depends on the algorithm ID as specified in {{tab-mlkem-artifacts}}.
+ - A fixed-length octet string containing the ML-KEM public key, whose length depends on the algorithm ID as specified in {{tab-mlkem-artifacts}}.
 
 The algorithm-specific secret key is these two values:
 
- - A fixed-length octet string of the encoded secret scalar, whose encoding and
-   length depend on the algorithm ID as specified in {{ecc-kem}}.
+ - A fixed-length octet string of the encoded secret scalar, whose encoding and length depend on the algorithm ID as specified in {{ecc-kem}}.
 
- - A fixed-length octet string containing the ML-KEM secret key, whose
-   length depends on the algorithm ID as specified in {{tab-mlkem-artifacts}}.
+ - A fixed-length octet string containing the ML-KEM secret key, whose length depends on the algorithm ID as specified in {{tab-mlkem-artifacts}}.
 
 # Composite Signature Schemes
 
@@ -1037,9 +857,8 @@ and
 
     (verified) <- EdDSA.Verify(eddsaPublicKey, eddsaSignature, dataDigest)
 
-The public and secret key, as well as the signature MUST be encoded according
-to [RFC8032] as fixed-length octet strings. The following table describes the
-EdDSA parameters and artifact lengths:
+The public and secret key, as well as the signature MUST be encoded according to [RFC8032] as fixed-length octet strings.
+The following table describes the EdDSA parameters and artifact lengths:
 
 {: title="EdDSA parameters and artifact lengths in octets" #tab-eddsa-artifacts}
 Algorithm ID reference | Curve   | Field size | Public key | Secret key | Signature
@@ -1059,10 +878,8 @@ and
     (verified) <- ECDSA.Verify(ecdsaPublicKey, ecdsaSignatureR,
                                ecdsaSignatureS, dataDigest)
 
-The public keys MUST be encoded in SEC1 format as defined in section
-{{sec1-format}}. The secret key, as well as both values `R` and `S` of the
-signature MUST each be encoded as a big-endian integer in a fixed-length octet
-string of the specified size.
+The public keys MUST be encoded in SEC1 format as defined in section {{sec1-format}}.
+The secret key, as well as both values `R` and `S` of the signature MUST each be encoded as a big-endian integer in a fixed-length octet string of the specified size.
 
 The following table describes the ECDSA parameters and artifact lengths:
 
@@ -1076,21 +893,18 @@ TBD (ML-DSA-87 + ECDSA-brainpoolP384r1) | brainpoolP384r1 | 48         | 97     
 
 ### ML-DSA signatures {#mldsa-signature}
 
-For ML-DSA signature generation the default hedged version of `ML-DSA.Sign`
-given in [FIPS-204] is used. That is, to sign with ML-DSA the following
-operation is defined:
+For ML-DSA signature generation the default hedged version of `ML-DSA.Sign` given in [FIPS-204] is used.
+That is, to sign with ML-DSA the following operation is defined:
 
     (mldsaSignature) <- ML-DSA.Sign(mldsaSecretKey, dataDigest)
 
-For ML-DSA signature verification the algorithm ML-DSA.Verify given in
-[FIPS-204] is used. That is, to verify with ML-DSA the following operation is
-defined:
+For ML-DSA signature verification the algorithm ML-DSA.Verify given in [FIPS-204] is used.
+That is, to verify with ML-DSA the following operation is defined:
 
     (verified) <- ML-DSA.Verify(mldsaPublicKey, dataDigest, mldsaSignature)
 
-ML-DSA has the parametrization with the corresponding artifact lengths in
-octets as given in {{tab-mldsa-artifacts}}. All artifacts are encoded as
-defined in [FIPS-204].
+ML-DSA has the parametrization with the corresponding artifact lengths in octets as given in {{tab-mldsa-artifacts}}.
+All artifacts are encoded as defined in [FIPS-204].
 
 {: title="ML-DSA parameters and artifact lengths in octets" #tab-mldsa-artifacts}
 Algorithm ID reference | ML-DSA    | Public key | Secret key | Signature value
@@ -1102,14 +916,11 @@ TBD                    | ML-DSA-87 | 2592       | 4896       | 4595
 
 ### Signature data digest {#mldsa-sig-data-digest}
 
-Signature data (i.e. the data to be signed) is digested prior to signing
-operations, see {{I-D.ietf-openpgp-crypto-refresh}} Section 5.2.4. Composite
-ML-DSA + ECC signatures MUST use the associated hash algorithm as specified in
-{{tab-mldsa-hash}} for the signature data digest. Signatures using other hash
-algorithms MUST be considered invalid.
+Signature data (i.e. the data to be signed) is digested prior to signing operations, see {{I-D.ietf-openpgp-crypto-refresh}} Section 5.2.4.
+Composite ML-DSA + ECC signatures MUST use the associated hash algorithm as specified in {{tab-mldsa-hash}} for the signature data digest.
+Signatures using other hash algorithms MUST be considered invalid.
 
-An implementation supporting a specific ML-DSA + ECC algorithm MUST also
-support the matching hash algorithm.
+An implementation supporting a specific ML-DSA + ECC algorithm MUST also support the matching hash algorithm.
 
 {: title="Binding between ML-DSA and signature data digest" #tab-mldsa-hash}
 Algorithm ID reference | Hash function | Hash function ID reference
@@ -1119,142 +930,102 @@ TBD (ML-DSA-87 IDs)    | SHA3-512      | 14
 
 ### Key generation procedure {#ecc-mldsa-generation}
 
-The implementation MUST independently generate the ML-DSA and the ECC
-component keys. ML-DSA key generation follows the specification
-[FIPS-204] and the artifacts are encoded as fixed-length octet strings as
-defined in {{mldsa-signature}}. For ECC this is done following the relative
-specification in {{RFC7748}}, {{SP800-186}}, or {{RFC5639}}, and encoding the
-artifacts as specified in {{eddsa-signature}} or {{ecdsa-signature}} as
-fixed-length octet strings.
+The implementation MUST independently generate the ML-DSA and the ECC component keys.
+ML-DSA key generation follows the specification [FIPS-204] and the artifacts are encoded as fixed-length octet strings as defined in {{mldsa-signature}}.
+For ECC this is done following the relative specification in {{RFC7748}}, {{SP800-186}}, or {{RFC5639}}, and encoding the artifacts as specified in {{eddsa-signature}} or {{ecdsa-signature}} as fixed-length octet strings.
 
 ### Signature Generation
 
-To sign a message `M` with ML-DSA + EdDSA the following sequence of
-operations has to be performed:
+To sign a message `M` with ML-DSA + EdDSA the following sequence of operations has to be performed:
 
- 1. Generate `dataDigest` according to {{I-D.ietf-openpgp-crypto-refresh}}
-    Section 5.2.4
+ 1. Generate `dataDigest` according to {{I-D.ietf-openpgp-crypto-refresh}} Section 5.2.4
 
- 2. Create the EdDSA signature over `dataDigest` with `EdDSA.Sign()` from
-    {{eddsa-signature}}
+ 2. Create the EdDSA signature over `dataDigest` with `EdDSA.Sign()` from {{eddsa-signature}}
 
- 3. Create the ML-DSA signature over `dataDigest` with `ML-DSA.Sign()` from
-    {{mldsa-signature}}
+ 3. Create the ML-DSA signature over `dataDigest` with `ML-DSA.Sign()` from {{mldsa-signature}}
 
- 4. Encode the EdDSA and ML-DSA signatures according to the packet structure
-    given in {{ecc-mldsa-sig-packet}}.
+ 4. Encode the EdDSA and ML-DSA signatures according to the packet structure given in {{ecc-mldsa-sig-packet}}.
 
-To sign a message `M` with ML-DSA + ECDSA the following sequence of
-operations has to be performed:
+To sign a message `M` with ML-DSA + ECDSA the following sequence of operations has to be performed:
 
- 1. Generate `dataDigest` according to {{I-D.ietf-openpgp-crypto-refresh}}
-    Section 5.2.4
+ 1. Generate `dataDigest` according to {{I-D.ietf-openpgp-crypto-refresh}} Section 5.2.4
 
- 2. Create the ECDSA signature over `dataDigest` with `ECDSA.Sign()` from
-    {{ecdsa-signature}}
+ 2. Create the ECDSA signature over `dataDigest` with `ECDSA.Sign()` from {{ecdsa-signature}}
 
- 3. Create the ML-DSA signature over `dataDigest` with `ML-DSA.Sign()` from
-    {{mldsa-signature}}
+ 3. Create the ML-DSA signature over `dataDigest` with `ML-DSA.Sign()` from {{mldsa-signature}}
 
- 4. Encode the ECDSA and ML-DSA signatures according to the packet structure
-    given in {{ecc-mldsa-sig-packet}}.
+ 4. Encode the ECDSA and ML-DSA signatures according to the packet structure given in {{ecc-mldsa-sig-packet}}.
 
 ### Signature Verification
 
-To verify a ML-DSA + EdDSA signature the following sequence of operations
-has to be performed:
+To verify a ML-DSA + EdDSA signature the following sequence of operations has to be performed:
 
  1. Verify the EdDSA signature with `EdDSA.Verify()` from {{eddsa-signature}}
 
  2. Verify the ML-DSA signature with `ML-DSA.Verify()` from {{mldsa-signature}}
 
-To verify a ML-DSA + ECDSA signature the following sequence of operations has
-to be performed:
+To verify a ML-DSA + ECDSA signature the following sequence of operations has to be performed:
 
  1. Verify the ECDSA signature with `ECDSA.Verify()` from {{ecdsa-signature}}
 
  2. Verify the ML-DSA signature with `ML-DSA.Verify()` from {{mldsa-signature}}
 
-As specified in {{composite-signatures}} an implementation MUST validate both
-signatures, i.e. EdDSA/ECDSA and ML-DSA, successfully to state that a composite ML-DSA + ECC
-signature is valid.
+As specified in {{composite-signatures}} an implementation MUST validate both signatures, i.e. EdDSA/ECDSA and ML-DSA, successfully to state that a composite ML-DSA + ECC signature is valid.
 
 ## Packet Specifications
 
 ### Signature Packet (Tag 2) {#ecc-mldsa-sig-packet}
 
-The composite ML-DSA + ECC schemes MUST be used only with v6 signatures, as
-defined in [I-D.ietf-openpgp-crypto-refresh].
+The composite ML-DSA + ECC schemes MUST be used only with v6 signatures, as defined in [I-D.ietf-openpgp-crypto-refresh].
 
-The algorithm-specific v6 signature parameters for ML-DSA + EdDSA signatures
-consists of:
+The algorithm-specific v6 signature parameters for ML-DSA + EdDSA signatures consists of:
 
- - A fixed-length octet string representing the EdDSA signature, whose length
-   depends on the algorithm ID as specified in {{tab-eddsa-artifacts}}.
+ - A fixed-length octet string representing the EdDSA signature, whose length depends on the algorithm ID as specified in {{tab-eddsa-artifacts}}.
 
- - A fixed-length octet string of the ML-DSA signature value, whose length
-   depends on the algorithm ID as specified in {{tab-mldsa-artifacts}}.
+ - A fixed-length octet string of the ML-DSA signature value, whose length depends on the algorithm ID as specified in {{tab-mldsa-artifacts}}.
 
-The algorithm-specific v6 signature parameters for ML-DSA + ECDSA signatures
-consists of:
+The algorithm-specific v6 signature parameters for ML-DSA + ECDSA signatures consists of:
 
- - A fixed-length octet string of the big-endian encoded ECDSA value `R`, whose
-   length depends on the algorithm ID as specified in {{tab-ecdsa-artifacts}}.
+ - A fixed-length octet string of the big-endian encoded ECDSA value `R`, whose length depends on the algorithm ID as specified in {{tab-ecdsa-artifacts}}.
 
- - A fixed-length octet string of the big-endian encoded ECDSA value `S`, whose
-   length depends on the algorithm ID as specified in {{tab-ecdsa-artifacts}}.
+ - A fixed-length octet string of the big-endian encoded ECDSA value `S`, whose length depends on the algorithm ID as specified in {{tab-ecdsa-artifacts}}.
 
- - A fixed-length octet string of the ML-DSA signature value, whose length
-   depends on the algorithm ID as specified in {{tab-mldsa-artifacts}}.
+ - A fixed-length octet string of the ML-DSA signature value, whose length depends on the algorithm ID as specified in {{tab-mldsa-artifacts}}.
 
 ### Key Material Packets
 
-The composite ML-DSA + ECC schemes MUST be used only with v6 keys, as defined
-in [I-D.ietf-openpgp-crypto-refresh].
+The composite ML-DSA + ECC schemes MUST be used only with v6 keys, as defined in [I-D.ietf-openpgp-crypto-refresh].
 
-The algorithm-specific public key for ML-DSA + EdDSA keys is this series of
-values:
+The algorithm-specific public key for ML-DSA + EdDSA keys is this series of values:
 
- - A fixed-length octet string representing the EdDSA public key, whose length
-   depends on the algorithm ID as specified in {{tab-eddsa-artifacts}}.
+ - A fixed-length octet string representing the EdDSA public key, whose length depends on the algorithm ID as specified in {{tab-eddsa-artifacts}}.
 
- - A fixed-length octet string containing the ML-DSA public key, whose length
-   depends on the algorithm ID as specified in {{tab-mldsa-artifacts}}.
+ - A fixed-length octet string containing the ML-DSA public key, whose length depends on the algorithm ID as specified in {{tab-mldsa-artifacts}}.
 
-The algorithm-specific secret key for ML-DSA + EdDSA keys is this series of
-values:
+The algorithm-specific secret key for ML-DSA + EdDSA keys is this series of values:
 
- - A fixed-length octet string representing the EdDSA secret key, whose length
-   depends on the algorithm ID as specified in {{tab-eddsa-artifacts}}.
+ - A fixed-length octet string representing the EdDSA secret key, whose length depends on the algorithm ID as specified in {{tab-eddsa-artifacts}}.
 
- - A fixed-length octet string containing the ML-DSA secret key, whose length
-   depends on the algorithm ID as specified in {{tab-mldsa-artifacts}}.
+ - A fixed-length octet string containing the ML-DSA secret key, whose length depends on the algorithm ID as specified in {{tab-mldsa-artifacts}}.
 
-The algorithm-specific public key for ML-DSA + ECDSA keys is this series of
-values:
+The algorithm-specific public key for ML-DSA + ECDSA keys is this series of values:
 
- - A fixed-length octet string representing the ECDSA public key in SEC1
-   format, as specified in section {{sec1-format}} and with length specified in
-   {{tab-ecdsa-artifacts}}.
+ - A fixed-length octet string representing the ECDSA public key in SEC1 format, as specified in section {{sec1-format}} and with length specified in {{tab-ecdsa-artifacts}}.
 
- - A fixed-length octet string containing the ML-DSA public key, whose length
-   depends on the algorithm ID as specified in {{tab-mldsa-artifacts}}.
+ - A fixed-length octet string containing the ML-DSA public key, whose length depends on the algorithm ID as specified in {{tab-mldsa-artifacts}}.
 
-The algorithm-specific secret key for ML-DSA + ECDSA keys is this series of
-values:
+The algorithm-specific secret key for ML-DSA + ECDSA keys is this series of values:
 
- - A fixed-length octet string representing the ECDSA secret key as a
-   big-endian encoded integer, whose length depends on the algorithm used as
-   specified in {{tab-ecdsa-artifacts}}.
+ - A fixed-length octet string representing the ECDSA secret key as a big-endian encoded integer, whose length depends on the algorithm used as specified in {{tab-ecdsa-artifacts}}.
 
- - A fixed-length octet string containing the ML-DSA secret key, whose length
-   depends on the algorithm ID as specified in {{tab-mldsa-artifacts}}.
+ - A fixed-length octet string containing the ML-DSA secret key, whose length depends on the algorithm ID as specified in {{tab-mldsa-artifacts}}.
 
 # SLH-DSA-SHAKE
 
 ## The SLH-DSA-SHAKE Algorithms {#slhdsa}
 
-The following table lists the group of algorithm code points for the SLH-DSA-SHAKE signature scheme and the corresponding artifact lengths. This group of algorithms is henceforth referred to as "SLH-DSA-SHAKE code points".
+The following table lists the group of algorithm code points for the SLH-DSA-SHAKE signature scheme and the corresponding artifact lengths.
+This group of algorithms is henceforth referred to as "SLH-DSA-SHAKE code points".
 
 {: title="SLH-DSA-SHAKE algorithm code points and the corresponding artifact lengths in octets." #slhdsa-artifact-lengths}
 Algorithm ID reference   |  SLH-DSA-SHAKE public key | SLH-DSA-SHAKE secret key | SLH-DSA-SHAKE signature
@@ -1265,14 +1036,11 @@ TBD (SLH-DSA-SHAKE-256s) |  64                 | 128                | 29792
 
 ### Signature Data Digest {#slhdsa-sig-data-digest}
 
-Signature data (i.e. the data to be signed) is digested prior to signing
-operations, see {{I-D.ietf-openpgp-crypto-refresh}} Section 5.2.4. SLH-DSA-SHAKE
-signatures MUST use the associated hash algorithm as specified in
-{{tab-slhdsa-hash}} for the signature data digest. Signatures using other hash
-algorithms MUST be considered invalid.
+Signature data (i.e. the data to be signed) is digested prior to signing operations, see {{I-D.ietf-openpgp-crypto-refresh}} Section 5.2.4.
+SLH-DSA-SHAKE signatures MUST use the associated hash algorithm as specified in {{tab-slhdsa-hash}} for the signature data digest.
+Signatures using other hash algorithms MUST be considered invalid.
 
-An implementation supporting a specific SLH-DSA-SHAKE algorithm code point MUST
-also support the matching hash algorithm.
+An implementation supporting a specific SLH-DSA-SHAKE algorithm code point MUST also support the matching hash algorithm.
 
 {: title="Binding between SLH-DSA-SHAKE algorithm code points and signature data hash algorithms" #tab-slhdsa-hash}
 Algorithm ID reference   |  Hash function | Hash function ID reference
@@ -1283,278 +1051,192 @@ TBD (SLH-DSA-SHAKE-256s) |  SHA3-512      | 14
 
 ### Key generation
 
-SLH-DSA-SHAKE key generation is performed via the algorithm `SLH-DSA.KeyGen` as
-specified in {{FIPS-205}}, and the artifacts are encoded as fixed-length octet
-strings as defined in {{slhdsa}}.
+SLH-DSA-SHAKE key generation is performed via the algorithm `SLH-DSA.KeyGen` as specified in {{FIPS-205}}, and the artifacts are encoded as fixed-length octet strings as defined in {{slhdsa}}.
 
 ### Signature Generation
 
-SLH-DSA-SHAKE signature generation is performed via the algorithm `SLH-DSA.Sign` as
-specified in {{FIPS-205}}. The variable `opt_rand` is set to `PK.seed`. See
-also {{slhdsa-sec-cons}}.
+SLH-DSA-SHAKE signature generation is performed via the algorithm `SLH-DSA.Sign` as specified in {{FIPS-205}}.
+The variable `opt_rand` is set to `PK.seed`.
+See also {{slhdsa-sec-cons}}.
 
 ### Signature Verification
 
-SLH-DSA-SHAKE signature verification is performed via the algorithm `SLH-DSA.Verify`
-as specified in {{FIPS-205}}.
+SLH-DSA-SHAKE signature verification is performed via the algorithm `SLH-DSA.Verify` as specified in {{FIPS-205}}.
 
 ## Packet specifications
 
 ###  Signature Packet (Tag 2)
 
-The SLH-DSA-SHAKE algorithms MUST be used only with v6 signatures, as defined in
-[I-D.ietf-openpgp-crypto-refresh] Section 5.2.3.
+The SLH-DSA-SHAKE algorithms MUST be used only with v6 signatures, as defined in [I-D.ietf-openpgp-crypto-refresh] Section 5.2.3.
 
 The algorithm-specific part of a signature packet for an SLH-DSA-SHAKE algorithm code point consists of:
 
- - A fixed-length octet string of the SLH-DSA-SHAKE signature value, whose length
-   depends on the algorithm ID in the format specified in
-   {{slhdsa-artifact-lengths}}.
+ - A fixed-length octet string of the SLH-DSA-SHAKE signature value, whose length depends on the algorithm ID in the format specified in {{slhdsa-artifact-lengths}}.
 
 ### Key Material Packets
 
-The SLH-DSA-SHAKE algorithms code points MUST be used only with v6 keys, as defined in
-[I-D.ietf-openpgp-crypto-refresh].
+The SLH-DSA-SHAKE algorithms code points MUST be used only with v6 keys, as defined in [I-D.ietf-openpgp-crypto-refresh].
 
 The algorithm-specific part of the public key consists of:
 
- - A fixed-length octet string containing the SLH-DSA-SHAKE public key, whose length
-   depends on the algorithm ID as specified in {{slhdsa-artifact-lengths}}.
+ - A fixed-length octet string containing the SLH-DSA-SHAKE public key, whose length depends on the algorithm ID as specified in {{slhdsa-artifact-lengths}}.
 
 The algorithm-specific part of the secret key consists of:
 
- - A fixed-length octet string containing the SLH-DSA-SHAKE secret key, whose length
-   depends on the algorithm ID as specified in {{slhdsa-artifact-lengths}}.
+ - A fixed-length octet string containing the SLH-DSA-SHAKE secret key, whose length depends on the algorithm ID as specified in {{slhdsa-artifact-lengths}}.
 
 # Notes on Algorithms
 
 ## Symmetric Algorithms for SEIPD Packets
 
 Implementations MUST implement `AES-256`.
-An implementation SHOULD use `AES-256` in the case of a v1 SEIPD packet,
-or `AES-256` with any available AEAD mode in the case of a v2 SEIPD packet,
-if all recipients indicate support for it (explicitly or implicitly).
+An implementation SHOULD use `AES-256` in the case of a v1 SEIPD packet, or `AES-256` with any available AEAD mode in the case of a v2 SEIPD packet, if all recipients indicate support for it (explicitly or implicitly).
 
-A v4 or v6 certificate that contains a PQ(/T) key SHOULD include
-`AES-256` in the "Preferred Symmetric Ciphers for v1 SEIPD" subpacket.
-A v6 certificate that contains a PQ(/T) key SHOULD include
-the pair `AES-256` with `OCB` in the "Preferred AEAD Ciphersuites" subpacket.
+A v4 or v6 certificate that contains a PQ(/T) key SHOULD include `AES-256` in the "Preferred Symmetric Ciphers for v1 SEIPD" subpacket.
+A v6 certificate that contains a PQ(/T) key SHOULD include the pair `AES-256` with `OCB` in the "Preferred AEAD Ciphersuites" subpacket.
 
-If `AES-256` is not explicitly in the list
-of the "Preferred Symmetric Ciphers for v1 SEIPD" subpacket,
-and if the certificate contains a PQ/T key, it is implicitly at the end of the list.
+If `AES-256` is not explicitly in the list of the "Preferred Symmetric Ciphers for v1 SEIPD" subpacket, and if the certificate contains a PQ/T key, it is implicitly at the end of the list.
 This is justified since `AES-256` is mandatory to implement.
 If `AES-128` is also implicitly added to the list, it is added after `AES-256`.
 
-If the pair `AES-256` with `OCB` is not explicitly in the list
-of the "Preferred AEAD Ciphersuites" subpacket,
-and if the certificate contains a PQ/T key, it is implicitly at the end of the list.
+If the pair `AES-256` with `OCB` is not explicitly in the list of the "Preferred AEAD Ciphersuites" subpacket, and if the certificate contains a PQ/T key, it is implicitly at the end of the list.
 This is justified since `AES-256` and `OCB` are mandatory to implement.
-If the pair `AES-128` with `OCB` is also implicitly added to the list,
-it is added after the pair `AES-256` with `OCB`.
+If the pair `AES-128` with `OCB` is also implicitly added to the list, it is added after the pair `AES-256` with `OCB`.
 
 # Migration Considerations
 
-The post-quantum KEM algorithms defined in {{kem-alg-specs}} and the signature
-algorithms defined in {{sig-alg-specs}} are a set of new public key algorithms
-that extend the algorithm selection of {{I-D.ietf-openpgp-crypto-refresh}}.
-During the transition period, the post-quantum algorithms will not be supported
-by all clients. Therefore various migration considerations must be taken into
-account, in particular backwards compatibility to existing implementations that
-have not yet been updated to support the post-quantum algorithms.
+The post-quantum KEM algorithms defined in {{kem-alg-specs}} and the signature algorithms defined in {{sig-alg-specs}} are a set of new public key algorithms that extend the algorithm selection of {{I-D.ietf-openpgp-crypto-refresh}}.
+During the transition period, the post-quantum algorithms will not be supported by all clients.
+Therefore various migration considerations must be taken into account, in particular backwards compatibility to existing implementations that have not yet been updated to support the post-quantum algorithms.
 
 ## Key preference
 
 Implementations SHOULD prefer PQ(/T) keys when multiple options are available.
 
-For instance, if encrypting for a recipient for which both a valid PQ/T and a
-valid ECC certificate are available, the implementation SHOULD choose the PQ/T
-certificate. In case a certificate has both a PQ/T and an ECC
-encryption-capable valid subkey, the PQ/T subkey SHOULD be preferred.
+For instance, if encrypting for a recipient for which both a valid PQ/T and a valid ECC certificate are available, the implementation SHOULD choose the PQ/T certificate.
+In case a certificate has both a PQ/T and an ECC encryption-capable valid subkey, the PQ/T subkey SHOULD be preferred.
 
-An implementation MAY sign with both a PQ(/T) and an ECC key using multiple
-signatures over the same data as described in {{multiple-signatures}}.
+An implementation MAY sign with both a PQ(/T) and an ECC key using multiple signatures over the same data as described in {{multiple-signatures}}.
 Signing only with PQ(/T) key material is not backwards compatible.
 
-Note that the confidentiality of a message is not post-quantum secure when
-encrypting to multiple recipients if at least one recipient does not support
-PQ/T encryption schemes. An implementation SHOULD NOT abort the encryption
-process in this case to allow for a smooth transition to post-quantum
-cryptography.
+Note that the confidentiality of a message is not post-quantum secure when encrypting to multiple recipients if at least one recipient does not support PQ/T encryption schemes.
+An implementation SHOULD NOT abort the encryption process in this case to allow for a smooth transition to post-quantum cryptography.
 
 ## Key generation strategies
 
-It is RECOMMENDED to generate fresh secrets when generating PQ(/T) keys. Note
-that reusing key material from existing ECC keys in PQ(/T) keys does not provide
-backwards compatibility.
+It is RECOMMENDED to generate fresh secrets when generating PQ(/T) keys.
+Note that reusing key material from existing ECC keys in PQ(/T) keys does not provide backwards compatibility.
 
-An OpenPGP certificate is composed of a certification-capable primary key
-and one or more subkeys for signature, encryption, and authentication.
+An OpenPGP certificate is composed of a certification-capable primary key and one or more subkeys for signature, encryption, and authentication.
 Two migration strategies are recommended:
 
-1. Generate two independent certificates, one for PQ(/T)-capable
-implementations, and one for legacy implementations. Implementations not
-understanding PQ(/T) certificates can use the legacy certificate, while
-PQ(/T)-capable implementations will prefer the newer certificate. This allows
-having an older v4 or v6 certificate for compatibility and a v6 PQ(/T)
-certificate, at a greater complexity in key distribution.
+1. Generate two independent certificates, one for PQ(/T)-capable implementations, and one for legacy implementations.
+   Implementations not understanding PQ(/T) certificates can use the legacy certificate, while PQ(/T)-capable implementations will prefer the newer certificate.
+   This allows having an older v4 or v6 certificate for compatibility and a v6 PQ(/T) certificate, at a greater complexity in key distribution.
 
 2. Attach PQ(/T) encryption subkeys to an existing traditional OpenPGP certificate.
-In the case of a v6 certificate, also PQ(/T) signature keys may be attached.
-Implementations understanding PQ(/T) will be able to parse and use
-the subkeys, while PQ(/T)-incapable implementations can gracefully ignore them.
-This simplifies key distribution, as only one certificate needs to be
-communicated and verified, but leaves the primary key vulnerable to quantum
-computer attacks.
+   In the case of a v6 certificate, also PQ(/T) signature keys may be attached.
+   Implementations understanding PQ(/T) will be able to parse and use the subkeys, while PQ(/T)-incapable implementations can gracefully ignore them.
+   This simplifies key distribution, as only one certificate needs to be communicated and verified, but leaves the primary key vulnerable to quantum computer attacks.
 
 # Security Considerations
 
 ## Security Aspects of Composite Signatures
 
-When multiple signatures are applied to a message, the question of the protocol's
-resistance against signature stripping attacks naturally arises. In a signature
-stripping attack, an adversary removes one or more of the transmitted signatures
-such that only a subset of the signatures originally applied by the sender remain
-in the message that reaches the recipient. This amounts to a downgrade attack
-that potentially reduces the value of the signature. It should be noted that the
-composite signature schemes specified in this draft are not subject to a
-signature stripping vulnerability. This is due to the fact that in any OpenPGP
-signature, the hashed meta data includes the signature algorithm ID, as specified
-in {{I-D.ietf-openpgp-crypto-refresh}}, Section 5.2.4. As a consequence, a
-component signature taken out of the context of a specific composite algorithm is
-not a valid signature for any message.
+When multiple signatures are applied to a message, the question of the protocol's resistance against signature stripping attacks naturally arises.
+In a signature stripping attack, an adversary removes one or more of the transmitted signatures such that only a subset of the signatures originally applied by the sender remain in the message that reaches the recipient.
+This amounts to a downgrade attack that potentially reduces the value of the signature.
+It should be noted that the composite signature schemes specified in this draft are not subject to a signature stripping vulnerability.
+This is due to the fact that in any OpenPGP signature, the hashed meta data includes the signature algorithm ID, as specified in {{I-D.ietf-openpgp-crypto-refresh}}, Section 5.2.4.
+As a consequence, a component signature taken out of the context of a specific composite algorithm is not a valid signature for any message.
 
-Furthermore, it is also not possible to craft a new signature for a message that
-was signed twice with a composite algorithm by interchanging (i.e., remixing) the
-component signatures, which would classify as a weak existential forgery. This is
-due to the fact that each v6 signatures also includes a random salt at the start
-of the hashed meta data, as also specified in the aforementioned reference.
+Furthermore, it is also not possible to craft a new signature for a message that was signed twice with a composite algorithm by interchanging (i.e., remixing) the component signatures, which would classify as a weak existential forgery.
+This is due to the fact that each v6 signatures also includes a random salt at the start of the hashed meta data, as also specified in the aforementioned reference.
 
 ## Hashing in ECC-KEM
 
-Our construction of the ECC-KEMs, in particular the inclusion of
-`eccCipherText` in the final hashing step in encapsulation and decapsulation
-that produces the `eccKeyShare`, is standard and known as hashed ElGamal key
-encapsulation, a hashed variant of ElGamal encryption. It ensures IND-CCA2
-security in the random oracle model under some Diffie-Hellman intractability
-assumptions [CS03]. The additional inclusion of `eccPublicKey` follows the
-security advice in Section 6.1 of {{RFC7748}}.
+Our construction of the ECC-KEMs, in particular the inclusion of `eccCipherText` in the final hashing step in encapsulation and decapsulation that produces the `eccKeyShare`, is standard and known as hashed ElGamal key encapsulation, a hashed variant of ElGamal encryption.
+It ensures IND-CCA2 security in the random oracle model under some Diffie-Hellman intractability assumptions [CS03].
+The additional inclusion of `eccPublicKey` follows the security advice in Section 6.1 of {{RFC7748}}.
 
 ## Key combiner {#sec-key-combiner}
 
-For the key combination in {{kem-key-combiner}} this specification limits
-itself to the use of KMAC. The sponge construction used by KMAC was proven to
-be indifferentiable from a random oracle {{BDPA08}}. This means, that in
-contrast to SHA2, which uses a Merkle-Damgard construction, no HMAC-based
-construction is required for key combination. Except for a domain separation it
-is sufficient to simply process the concatenation of any number of key shares
-when using a sponge-based construction like KMAC. The construction using KMAC
-ensures a standardized domain separation. In this case, the processed message
-is then the concatenation of any number of key shares.
+For the key combination in {{kem-key-combiner}} this specification limits itself to the use of KMAC.
+The sponge construction used by KMAC was proven to be indifferentiable from a random oracle {{BDPA08}}.
+This means, that in contrast to SHA2, which uses a Merkle-Damgard construction, no HMAC-based construction is required for key combination.
+Except for a domain separation it is sufficient to simply process the concatenation of any number of key shares when using a sponge-based construction like KMAC.
+The construction using KMAC ensures a standardized domain separation.
+In this case, the processed message is then the concatenation of any number of key shares.
 
-More precisely, for a given capacity `c` the indifferentiability proof shows
-that assuming there are no weaknesses found in the Keccak permutation, an
-attacker has to make an expected number of `2^(c/2)` calls to the permutation
-to tell KMAC from a random oracle. For a random oracle, a difference in only a
-single bit gives an unrelated, uniformly random output. Hence, to be able to
-distinguish a key `K`, derived from shared keys `K1` and `K2` (and ciphertexts
-`C1` and `C2`) as
+More precisely, for a given capacity `c` the indifferentiability proof shows that assuming there are no weaknesses found in the Keccak permutation, an attacker has to make an expected number of `2^(c/2)` calls to the permutation to tell KMAC from a random oracle.
+For a random oracle, a difference in only a single bit gives an unrelated, uniformly random output.
+Hence, to be able to distinguish a key `K`, derived from shared keys `K1` and `K2` (and ciphertexts `C1` and `C2`) as
 
-    K = KMAC(domainSeparation, counter || K1 || C1 || K2 || C2 || fixedInfo,
-             outputBits, customization)
+    K = KMAC(domainSeparation, counter || K1 || C1 || K2 || C2 || fixedInfo, outputBits, customization)
 
-from a random bit string, an adversary has to know (or correctly guess) both
-key shares `K1` and `K2`, entirely.
+from a random bit string, an adversary has to know (or correctly guess) both key shares `K1` and `K2`, entirely.
 
-The proposed construction in {{kem-key-combiner}} preserves IND-CCA2 of any of
-its ingredient KEMs, i.e. the newly formed combined KEM is IND-CCA2 secure as
-long as at least one of the ingredient KEMs is. Indeed, the above stated
-indifferentiability from a random oracle qualifies Keccak as a split-key
-pseudorandom function as defined in {{GHP18}}. That is, Keccak behaves like a
-random function if at least one input shared secret is picked uniformly at
-random. Our construction can thus be seen as an instantiation of the IND-CCA2
-preserving Example 3 in Figure 1 of {{GHP18}}, up to some reordering of input
-shared secrets and ciphertexts. In the random oracle setting, the reordering
-does not influence the arguments in {{GHP18}}.
+The proposed construction in {{kem-key-combiner}} preserves IND-CCA2 of any of its ingredient KEMs, i.e. the newly formed combined KEM is IND-CCA2 secure as long as at least one of the ingredient KEMs is.
+Indeed, the above stated indifferentiability from a random oracle qualifies Keccak as a split-key pseudorandom function as defined in {{GHP18}}.
+That is, Keccak behaves like a random function if at least one input shared secret is picked uniformly at random.
+Our construction can thus be seen as an instantiation of the IND-CCA2 preserving Example 3 in Figure 1 of {{GHP18}}, up to some reordering of input shared secrets and ciphertexts.
+In the random oracle setting, the reordering does not influence the arguments in {{GHP18}}.
 
 ## Domain separation and binding {#sec-fixed-info}
 
-The `domSeparation` information defined in {{kem-key-combiner}} provides the
-domain separation for the key combiner construction. This ensures that the
-input keying material is used to generate a KEK for a specific purpose or
-context.
+The `domSeparation` information defined in {{kem-key-combiner}} provides the domain separation for the key combiner construction.
+This ensures that the input keying material is used to generate a KEK for a specific purpose or context.
 
-The `fixedInfo` defined in {{kem-fixed-info}} binds the derived KEK to the
-chosen algorithm and communication parties. The algorithm ID identifies
-unequivocally the algorithm, the parameters for its instantiation, and the length
-of all artifacts, including the derived key.
+The `fixedInfo` defined in {{kem-fixed-info}} binds the derived KEK to the chosen algorithm and communication parties.
+The algorithm ID identifies unequivocally the algorithm, the parameters for its instantiation, and the length of all artifacts, including the derived key.
 
-This is in line with the Recommendation for ECC in section 5.5 of
-[SP800-56A]. Other fields included in the recommendation are not relevant
-for the OpenPGP protocol, since the sender is not required to have a key of
-their own, there are no pre-shared secrets, and all the other parameters are
-unequivocally defined by the algorithm ID.
+This is in line with the Recommendation for ECC in section 5.5 of [SP800-56A].
+Other fields included in the recommendation are not relevant for the OpenPGP protocol, since the sender is not required to have a key of their own, there are no pre-shared secrets, and all the other parameters are unequivocally defined by the algorithm ID.
 
-Furthermore, we do not require the recipients public key into the key combiner
-as the public key material is already included in the component key derivation
-functions.
-Given two KEMs which we assume to be multi-user secure, we combine their outputs
-using a KEM-combiner:
+Furthermore, we do not require the recipients public key into the key combiner as the public key material is already included in the component key derivation functions.
+Given two KEMs which we assume to be multi-user secure, we combine their outputs using a KEM-combiner:
 
     K = H(K1, C1, K2, C2), C = (C1, C2)
 
-Our aim is to preserve multi-user security. A common approach to this is to add
-the public key into the key derivation for K. However, it turns out that this is
-not necessary here. To break security of the combined scheme in the multi-user
-setting, the adversary has to distinguish a set of challenge keys
+Our aim is to preserve multi-user security.
+A common approach to this is to add the public key into the key derivation for K.
+However, it turns out that this is not necessary here.
+To break security of the combined scheme in the multi-user setting, the adversary has to distinguish a set of challenge keys
 
   K*_u = H(K1*_u, C1*_u, K2*_u, C2*_u)
 
-for users u in some set from random, also given ciphertexts `C*_u = (C1*_u,
-C2*_u)`. For each of these K* it holds that if the adversary never makes a
-query
+for users u in some set from random, also given ciphertexts `C*_u = (C1*_u, C2*_u)`.
+For each of these K* it holds that if the adversary never makes a query
 
     H(K1*_u, C1*_u, K2*_u, C2*_u)
 
 they have a zero advantage over guessing.
 
-The only multi-user advantage that the adversary could gain therefore consists
-of queries to H that are meaningful for two different users u1 != u2 and their
-associated public keys. This is only the case if
+The only multi-user advantage that the adversary could gain therefore consists of queries to H that are meaningful for two different users u1 != u2 and their associated public keys.
+This is only the case if
 
     (c1*_u1, c2*_u1) = (c1*_u2, c2*_u2)
 
 as the ciphertext values decide for which challenge the query is meaningful.
-This means that a ciphertext collision is needed between challenges. Assuming
-that the randomness used in the generation of the two challenges is
-uncorrelated, this is negligible.
+This means that a ciphertext collision is needed between challenges.
+Assuming that the randomness used in the generation of the two challenges is uncorrelated, this is negligible.
 
-In consequence, the ciphertexts already work sufficiently well as
-domain-separator.
+In consequence, the ciphertexts already work sufficiently well as domain-separator.
 
 ## SLH-DSA-SHAKE Message Randomizer {#slhdsa-sec-cons}
 
-The specification of SLH-DSA-SHAKE {{FIPS-205}} prescribes an optional
-non-deterministic message randomizer. This is not used in this specification,
-as OpenPGP v6 signatures already provide a salted signature data digest of the
-appropriate size.
+The specification of SLH-DSA-SHAKE {{FIPS-205}} prescribes an optional non-deterministic message randomizer.
+This is not used in this specification, as OpenPGP v6 signatures already provide a salted signature data digest of the appropriate size.
 
 ## Binding hashes in signatures with signature algorithms
 
-In order not to extend the attack surface, we bind the hash algorithm used for
-signature data digestion to the hash algorithm used internally by the signature
-algorithm.
+In order not to extend the attack surface, we bind the hash algorithm used for signature data digestion to the hash algorithm used internally by the signature algorithm.
 
-ML-DSA internally uses a SHAKE256 digest, therefore we require SHA3 in the
-ML-DSA + ECC signature packet, see {{mldsa-sig-data-digest}}. Note that we bind
-a NIST security category 2 hash function to a signature algorithm that falls
-into NIST security category 3. This does not constitute a security bottleneck:
-because of the unpredictable random salt that is prepended to the digested data
-in v6 signatures, the hardness assumption is not collision resistance but
-second-preimage resistance.
+ML-DSA internally uses a SHAKE256 digest, therefore we require SHA3 in the ML-DSA + ECC signature packet, see {{mldsa-sig-data-digest}}.
+Note that we bind a NIST security category 2 hash function to a signature algorithm that falls into NIST security category 3.
+This does not constitute a security bottleneck: because of the unpredictable random salt that is prepended to the digested data in v6 signatures, the hardness assumption is not collision resistance but second-preimage resistance.
 
-In the case of SLH-DSA-SHAKE the internal hash algorithm varies based on the
-algorithm ID, see {{slhdsa-sig-data-digest}}.
+In the case of SLH-DSA-SHAKE the internal hash algorithm varies based on the algorithm ID, see {{slhdsa-sig-data-digest}}.
 
 ## Symmetric Algorithms for SEIPD Packets
 
@@ -1562,62 +1244,41 @@ This specification mandates support for `AES-256` for two reasons.
 First, `AES-KeyWrap` with `AES-256` is already part of the composite KEM construction.
 Second, some of the PQ(/T) algorithms target the security level of `AES-256`.
 
-For the same reasons, this specification further recommends the use of `AES-256`
-if it is supported by all recipients, regardless of what the implementation
-would otherwise choose based on the recipients' preferences.
-This recommendation should be understood as a clear and simple rule
-for the selection of `AES-256` for encryption.
+For the same reasons, this specification further recommends the use of `AES-256` if it is supported by all recipients, regardless of what the implementation would otherwise choose based on the recipients' preferences.
+This recommendation should be understood as a clear and simple rule for the selection of `AES-256` for encryption.
 Implementations may also make more nuanced decisions.
 
 # Additional considerations
 
 ## Performance Considerations for SLH-DSA-SHAKE {#performance-considerations}
 
-This specification introduces both ML-DSA + ECC as well as SLH-DSA-SHAKE as PQ(/T)
-signature schemes.
+This specification introduces both ML-DSA + ECC as well as SLH-DSA-SHAKE as PQ(/T) signature schemes.
 
-Generally, it can be said that ML-DSA + ECC provides a performance in terms of
-execution time requirements that is close to that of traditional ECC signature
-schemes.
-Regarding the size of signatures and public keys, though, ML-DSA has far greater
-requirements than traditional schemes like EC-based or even RSA
-signature schemes.
+Generally, it can be said that ML-DSA + ECC provides a performance in terms of execution time requirements that is close to that of traditional ECC signature schemes.
+Regarding the size of signatures and public keys, though, ML-DSA has far greater requirements than traditional schemes like EC-based or even RSA signature schemes.
 
-Implementers may want to offer SLH-DSA-SHAKE for applications where the weaker
-security assumptions of a hash-based signature scheme are required – namely only the 2nd preimage resistance of a hash function – and thus a
-potentially higher degree of trust in the long-term security of signatures is
-achieved. However, SLH-DSA-SHAKE has performance characteristics in terms of
-execution time of the signature generation as well as space requirements for the
-signature that are even greater than those of ML-DSA + ECC signature schemes.
+Implementers may want to offer SLH-DSA-SHAKE for applications where the weaker security assumptions of a hash-based signature scheme are required – namely only the 2nd preimage resistance of a hash function – and thus a potentially higher degree of trust in the long-term security of signatures is achieved.
+However, SLH-DSA-SHAKE has performance characteristics in terms of execution time of the signature generation as well as space requirements for the signature that are even greater than those of ML-DSA + ECC signature schemes.
 
-Pertaining to the execution time, the particularly costly operation in
-SLH-DSA-SHAKE is the signature generation. Depending on the parameter
-set, it can range from approximately the one hundred fold to more than the two
-thousand fold of that of ML-DSA-87.
+Pertaining to the execution time, the particularly costly operation in SLH-DSA-SHAKE is the signature generation.
+Depending on the parameter set, it can range from approximately the one hundred fold to more than the two thousand fold of that of ML-DSA-87.
 These number are based on the performance measurements published in the NIST submissions for SLH-DSA-SHAKE and ML-DSA.
-In order to achieve fast signature
-generation times, the algorithm SLH-DSA-SHAKE-128f ("f" standing for "fast")
-should be chosen. This comes at the expense of a larger signature size.  This
-choice can be relevant in applications where mass signing occurs or a small
-latency is required.
+In order to achieve fast signature generation times, the algorithm SLH-DSA-SHAKE-128f ("f" standing for "fast") should be chosen.
+This comes at the expense of a larger signature size.
+This choice can be relevant in applications where mass signing occurs or a small latency is required.
 
-In order to minimize the space requirements of an SLH-DSA-SHAKE signature, an
-algorithm ID with the name ending in "s" for "small" should be chosen. This comes
-at the expense of a longer signature generation time. In particular,
-SLH-DSA-SHAKE-128s achieves the smallest possible signature size, which is about
-the double size of an ML-DSA-87 signature. Where a higher
-security level than 128 bit is needed, SLH-DSA-SHAKE-256s can be used.
+In order to minimize the space requirements of an SLH-DSA-SHAKE signature, an algorithm ID with the name ending in "s" for "small" should be chosen.
+This comes at the expense of a longer signature generation time.
+In particular, SLH-DSA-SHAKE-128s achieves the smallest possible signature size, which is about the double size of an ML-DSA-87 signature.
+Where a higher security level than 128 bit is needed, SLH-DSA-SHAKE-256s can be used.
 
-Unlike the signature generation time, the signature verification time of
-SLH-DSA-SHAKE is not that much larger than that of other PQC schemes. Based on
-the performance measurements published in the NIST submissions for SLH-DSA-SHAKE
-and ML-DSA, the verification time of the SLH-DSA-SHAKE is, for the parameters
-covered by this specification, larger than that of ML-DSA-87 by a factor ranging
-from four (for -128s) over nine (for -256s) to twelve (for -128f).
+Unlike the signature generation time, the signature verification time of SLH-DSA-SHAKE is not that much larger than that of other PQC schemes.
+Based on the performance measurements published in the NIST submissions for SLH-DSA-SHAKE and ML-DSA, the verification time of the SLH-DSA-SHAKE is, for the parameters covered by this specification, larger than that of ML-DSA-87 by a factor ranging from four (for -128s) over nine (for -256s) to twelve (for -128f).
 
 # IANA Considerations
 
-IANA is requested to add the algorithm IDs defined in {{iana-pubkey-algos}} to the existing registry `OpenPGP Public Key Algorithms`. The field specifications enclosed in brackets for the ML-KEM + ECDH composite algorithms denote fields that are only conditionally contained in the data structure.
+IANA is requested to add the algorithm IDs defined in {{iana-pubkey-algos}} to the existing registry `OpenPGP Public Key Algorithms`.
+The field specifications enclosed in brackets for the ML-KEM + ECDH composite algorithms denote fields that are only conditionally contained in the data structure.
 
 
 {: title="IANA updates for registry 'OpenPGP Public Key Algorithms'" #iana-pubkey-algos}
@@ -1669,11 +1330,9 @@ TBD    | SLH-DSA-SHAKE-256s  | 64 octets public key ({{slhdsa-artifact-lengths}}
 ## draft-ietf-openpgp-pqc-01
 
 - Mandated `AES-256` as mandatory to implement.
-- Added `AES-256` / `AES-128` with `OCB`
-  implicitly to v1/v2 SEIPD preferences of "PQ(/T) certificates".
+- Added `AES-256` / `AES-128` with `OCB` implicitly to v1/v2 SEIPD preferences of "PQ(/T) certificates".
 - Added a recommendation to use `AES-256` when possible.
-- Swapped the optional v3 PKESK algorithm identifier with length octet
-  in order to align with X25519 and X448.
+- Swapped the optional v3 PKESK algorithm identifier with length octet in order to align with X25519 and X448.
 - Fixed ML-DSA private key size
 - Added test vectors
 - correction and completion of IANA instructions
@@ -1824,5 +1483,4 @@ The hex-encoded session key is `27e3c564fa7b8adb7ee1cfede3ee2cda79dd8f1a6d029ebe
 # Acknowledgments
 {:numbered="false"}
 
-Thanks to Daniel Huigens and Evangelos Karatsiolis for the early review and
-feedback on this document.
+Thanks to Daniel Huigens and Evangelos Karatsiolis for the early review and feedback on this document.

--- a/draft-ietf-openpgp-pqc.md
+++ b/draft-ietf-openpgp-pqc.md
@@ -1172,7 +1172,8 @@ More precisely, for a given capacity `c` the indifferentiability proof shows tha
 For a random oracle, a difference in only a single bit gives an unrelated, uniformly random output.
 Hence, to be able to distinguish a key `K`, derived from shared keys `K1` and `K2` (and ciphertexts `C1` and `C2`) as
 
-    K = KMAC(domainSeparation, counter || K1 || C1 || K2 || C2 || fixedInfo, outputBits, customization)
+    K = KMAC(domainSeparation, counter || K1 || C1 || K2 || C2 || fixedInfo,
+    outputBits, customization)
 
 from a random bit string, an adversary has to know (or correctly guess) both key shares `K1` and `K2`, entirely.
 


### PR DESCRIPTION
I checked the reformatted text to be word-by-word equal to the previous version using [wdiff](https://www.gnu.org/software/wdiff/): `wdiff --no-common ...`.
