### PR TITLE
Allow algorithm 35 with v4 keys

### DIFF
--- a/draft-ietf-openpgp-pqc.md
+++ b/draft-ietf-openpgp-pqc.md
@@ -423,10 +423,8 @@ Furthermore, when performing the explicitly listed operations in {{x25519-kem}} 
 
 ## Key version binding
 
-All (PQ/T) asymmetric algorithms are to be used only in v6 (and newer) keys and certificates, with the single exception of ML-KEM-768+X25519 (algorithm ID 35).
-For existing certificates, algorithm 35 is also permitted for use in v4 encryption-capable subkeys.
+All (PQ/T) asymmetric algorithms are to be used only in v6 (and newer) keys and certificates, with the single exception of ML-KEM-768+X25519 (algorithm ID 35), which is also allowed in v4 encryption-capable subkeys.
 This permits the keyholder of an existing v4 certificate to add such a subkey to defend against store-now, decrypt-later attacks from quantum computers without moving to a new primary key.
-New keys and certificates should use v6 for the full range of post-quantum algorithms.
 
 # Composite KEM schemes
 
@@ -677,7 +675,7 @@ Implementations MUST NOT use the obsolete Symmetrically Encrypted Data packet (t
 
 The composite ML-KEM-768 + X25519 (algorithm ID 35) MUST be used only with v4 or v6 keys, as defined in [RFC9580], or newer versions defined by updates of that document.
 
-The composite ML-KEM-1024 + X448 (algorithm ID 36) MUST be used only with v6 keys, as defined in [RFC9580], or newer versions defined by updates of that document
+The composite ML-KEM-1024 + X448 (algorithm ID 36) MUST be used only with v6 keys, as defined in [RFC9580], or newer versions defined by updates of that document.
 
 The algorithm-specific public key is this series of values:
 

--- a/draft-ietf-openpgp-pqc.md
+++ b/draft-ietf-openpgp-pqc.md
@@ -422,8 +422,11 @@ Even though the zero point, also called the point at infinity, may occur as a re
 Furthermore, when performing the explicitly listed operations in {{x25519-kem}} or {{x448-kem}} it is REQUIRED to follow the specification and security advisory mandated from the respective elliptic curve specification.
 
 ## Key version binding
-These asymmetric algorithms are to be used only in v6 TPKs and TSKs, with the single exception of ML-KEM-768+X25519 (algorithm ID 35).
-Algorithm 35 is also permitted for use in v4 TPKs and TSKs for the purpose of defending OpenPGP messages encrypted to existing certificates against store-now, decrypt-later attacks that use quantum computing machinery.
+
+All (PQ/T) asymmetric algorithms are to be used only in v6 (and newer) keys and certificates, with the single exception of ML-KEM-768+X25519 (algorithm ID 35).
+For existing certificates, algorithm 35 is also permitted for use in v4 encryption-capable subkeys.
+This permits the keyholder of an existing v4 certificate to add such a subkey to defend against store-now, decrypt-later attacks from quantum computers without moving to a new primary key.
+New keys and certificates should use v6 for the full range of post-quantum algorithms.
 
 # Composite KEM schemes
 

--- a/draft-ietf-openpgp-pqc.md
+++ b/draft-ietf-openpgp-pqc.md
@@ -421,6 +421,10 @@ Even though the zero point, also called the point at infinity, may occur as a re
 
 Furthermore, when performing the explicitly listed operations in {{x25519-kem}} or {{x448-kem}} it is REQUIRED to follow the specification and security advisory mandated from the respective elliptic curve specification.
 
+## Key version binding
+These asymmetric algorithms are to be used only in v6 TPKs and TSKs, with the single exception of ML-KEM-768+X25519 (algorithm ID 35).
+Algorithm 35 is also permitted for use in v4 TPKs and TSKs for the purpose of defending OpenPGP messages encrypted to existing certificates against store-now, decrypt-later attacks that use quantum computing machinery.
+
 # Composite KEM schemes
 
 ## Building Blocks

--- a/draft-ietf-openpgp-pqc.md
+++ b/draft-ietf-openpgp-pqc.md
@@ -668,7 +668,9 @@ Implementations MUST NOT use the obsolete Symmetrically Encrypted Data packet (t
 
 ### Key Material Packets {#mlkem-ecc-key}
 
-The composite ML-KEM + ECDH schemes MUST be used only with v6 keys, as defined in [RFC9580], or newer versions defined by updates of that document.
+The composite ML-KEM-768 + X25519 (algorithm ID 35) MUST be used only with v4 or v6 keys, as defined in [RFC9580], or newer versions defined by updates of that document.
+
+The composite ML-KEM-1024 + X448 (algorithm ID 36) MUST be used only with v6 keys, as defined in [RFC9580], or newer versions defined by updates of that document
 
 The algorithm-specific public key is this series of values:
 
@@ -1092,6 +1094,7 @@ ID     | Algorithm           | Public Key Format                                
 ## draft-ietf-openpgp-pqc-08
 - Assign code points 35 and 36 for ML-KEM + ECDH algorithms.
 - Removed hash binding for ML-DSA + EdDSA and SLH-DSA algorithms.
+- Allow usage of ML-KEM-768 + X25519 with v4 keys
 
 # Contributors
 


### PR DESCRIPTION
As discussed at the OpenPGP summit, allow ML-KEM-768 + X25519 to be used with v4 keys