### PR TITLE
Attempt at clarifying certificate structure

### DIFF
--- a/draft-ietf-openpgp-pqc.md
+++ b/draft-ietf-openpgp-pqc.md
@@ -842,7 +842,7 @@ Signing only with PQ(/T) key material is not backwards compatible.
 It is RECOMMENDED to generate fresh secrets when generating PQ(/T) keys.
 Note that reusing key material from existing ECC keys in PQ(/T) keys does not provide backwards compatibility.
 
-An OpenPGP certificate is composed of a certification-capable primary key and one or more subkeys for signature, encryption, and authentication.
+An OpenPGP certificate is composed of a primary key which is often marked as capable of issuing third-party certifications, and possibly other additional capabilities, and one or more subkeys for data signatures, encryption, and authentication.
 Two migration strategies are recommended:
 
 1. Generate two independent certificates, one for PQ(/T)-capable implementations, and one for legacy implementations.


### PR DESCRIPTION
A primary key is implicitly capable of issuing self-signatures for certificate formation and life cycle management (this might be best omitted in this text)

It may be marked "certification"-capable, which allows it to issue valid third-party certifications (however, primary keys may exist without this capability)

The primary can in principle fulfill all capabilities (however, except for the case of RSA, it can't in practice be used for encryption, when its asymmetric mechanism only supports signing operations). Still, even with modern keys, the primary may be used for data signatures and authentication (and at least in some special-purposes scenarios, this may be a reasonable approach)