### PR TITLE
Specify minimum requirements for signature digest sizes

### DIFF
--- a/draft-ietf-openpgp-pqc.md
+++ b/draft-ietf-openpgp-pqc.md
@@ -894,7 +894,7 @@ This has the advantage of an enhanced side-channel resistance of the signature o
 ## Minimum digest size for PQ(/T)-signatures
 
 This specification requires that all PQ(/T) signatures defined in this document are made in combination with a hash algorithm of at least 256 bits digest size.
-The relevant security property is preimage resistance, since all signature algorithms defined in this document require signature packets of version 6 or higher, which include a random salt value.
+The relevant security property is preimage resistance, since all signature algorithms defined in this document require signature packets of version 6 or higher, which currently include a random salt prefix.
 Therefore, a hash algorithm with 256 bits digest size is sufficient to match the targeted security level of all PQ(/T) algorithms defined in this document.
 Note that the minimum hash algorithm digest size requirement is different for signature schemes that are defined in [RFC9580], where signature algorithms are also allowed to be used with non-salted v4 signatures.
 In such cases, the relevant security property is collision resistance.

--- a/draft-ietf-openpgp-pqc.md
+++ b/draft-ietf-openpgp-pqc.md
@@ -795,7 +795,7 @@ The algorithm-specific part of a signature packet for an SLH-DSA algorithm code 
 
  - A fixed-length octet string of the SLH-DSA signature value, whose length depends on the algorithm ID in the format specified in {{slhdsa-artifact-lengths}}.
 
-An SLH-DSA signature MUST use a hash algorithm with a digest size of at least 256 bits.
+An SLH-DSA signature MUST use a hash algorithm with a digest size of at least 256 bits for the computation of the message digest.
 A verifying implementation MUST reject any SLH-DSA signature that uses a hash algorithm with a smaller digest size.
 
 ### Key Material Packets

--- a/draft-ietf-openpgp-pqc.md
+++ b/draft-ietf-openpgp-pqc.md
@@ -735,7 +735,7 @@ The algorithm-specific v6 signature parameters for ML-DSA + EdDSA signatures con
 
  - A fixed-length octet string of the ML-DSA signature value, whose length depends on the algorithm ID as specified in {{tab-mldsa-artifacts}}.
 
-A composite ML-DSA + EdDSA signature MUST use a hash algorithm with a digest size of at least 256 bits.
+A composite ML-DSA + EdDSA signature MUST use a hash algorithm with a digest size of at least 256 bits for the computation of the message digest.
 A verifying implementation MUST reject any composite ML-DSA + EdDSA signature that uses a hash algorithm with a smaller digest size.
 
 ### Key Material Packets

--- a/draft-ietf-openpgp-pqc.md
+++ b/draft-ietf-openpgp-pqc.md
@@ -896,7 +896,6 @@ This has the advantage of an enhanced side-channel resistance of the signature o
 This specification requires that all PQ(/T) signatures defined in this document are made on message digests computed with a hash algorithm with at least 256 bits of digest size.
 Since all signature algorithms defined in this document require signature packets of version 6 or higher, which currently include a leading random salt value in the hashed data, hash-collision attacks do not apply to the signature schemes defined in this specification.
 Therefore, a hash algorithm with a digest size of 256 bits is sufficient to match the targeted security level of all PQ(/T) algorithms defined in this document, as it achieves a preimage and second preimage security of 256 bits.
-In such cases, the relevant security property is collision resistance.
 
 ## Symmetric Algorithms for SEIPD Packets
 

--- a/draft-ietf-openpgp-pqc.md
+++ b/draft-ietf-openpgp-pqc.md
@@ -893,7 +893,7 @@ This has the advantage of an enhanced side-channel resistance of the signature o
 
 ## Minimum digest size for PQ(/T)-signatures
 
-This specification requires that all PQ(/T) signatures defined in this document are made in combination with a hash algorithm of at least 256 bits digest size.
+This specification requires that all PQ(/T) signatures defined in this document are made on message digests computed with a hash algorithm with at least 256 bits of digest size.
 The relevant security property is preimage resistance, since all signature algorithms defined in this document require signature packets of version 6 or higher, which currently include a random salt prefix.
 Therefore, a hash algorithm with 256 bits digest size is sufficient to match the targeted security level of all PQ(/T) algorithms defined in this document.
 Note that the minimum hash algorithm digest size requirement is different for signature schemes that are defined in [RFC9580], where signature algorithms are also allowed to be used with non-salted v4 signatures.

--- a/draft-ietf-openpgp-pqc.md
+++ b/draft-ietf-openpgp-pqc.md
@@ -739,10 +739,10 @@ A composite ML-DSA + EdDSA signature MUST use a hash algorithm whose digest size
 A verifying implementation MUST reject any composite ML-DSA + EdDSA signature that uses a hash algorithm with a smaller digest size.
 
 {: title="Minimum hash algorithm digest size for composite ML-DSA + EdDSA signatures in bits" #tab-min-mldsa-eddsa-digest-size}
-Signature algorithm | Minimum digest size
-:-------------------| ------------------
-ML-DSA-65+Ed25519   | 384
-ML-DSA-87+Ed448     | 512
+ID | Algorithm         | Minimum digest size
+:--|:------------------|--------------------
+30 | ML-DSA-65+Ed25519 | 384
+31 | ML-DSA-87+Ed448   | 512
 
 ### Key Material Packets
 
@@ -805,11 +805,11 @@ An SLH-DSA signature MUST use a hash algorithm whose digest size meets or exceed
 A verifying implementation MUST reject any SLH-DSA signature that uses a hash algorithm with a smaller digest size.
 
 {: title="Minimum hash algorithm digest size for SLH-DSA signatures in bits" #tab-min-slhdsa-digest-size}
-Signature algorithm | Minimum digest size
-:-------------------| ------------------
-SLH-DSA-SHAKE-128s  | 256
-SLH-DSA-SHAKE-128f  | 256
-SLH-DSA-SHAKE-256s  | 512
+ID | Algorithm           | Minimum digest size
+:--|:--------------------| ------------------
+32 | SLH-DSA-SHAKE-128s  | 256
+33 | SLH-DSA-SHAKE-128f  | 256
+34 | SLH-DSA-SHAKE-256s  | 512
 
 ### Key Material Packets
 

--- a/draft-ietf-openpgp-pqc.md
+++ b/draft-ietf-openpgp-pqc.md
@@ -894,8 +894,8 @@ This has the advantage of an enhanced side-channel resistance of the signature o
 ## Minimum digest size for PQ(/T)-signatures
 
 This specification requires that all PQ(/T) signatures defined in this document are made on message digests computed with a hash algorithm with at least 256 bits of digest size.
-Since all signature algorithms defined in this document require signature packets of version 6 or higher, which currently include a leading random salt value in the hashed data, hash-collision attacks do not apply to the signature schemes defined in this specification.
-Therefore, a hash algorithm with a digest size of 256 bits is sufficient to match the targeted security level of all PQ(/T) algorithms defined in this document, as it achieves a preimage and second preimage security of 256 bits.
+Since all signature algorithms defined in this document require version 6 (and newer) signature packets, which currently include a leading random salt value in the hashed data, the required property is not collision but (2nd) preimage resistance.
+Therefore, a hash algorithm with a digest size of at least 256 bits is sufficient to match the targeted security levels of all PQ(/T) algorithms defined in this document.
 
 ## Symmetric Algorithms for SEIPD Packets
 

--- a/draft-ietf-openpgp-pqc.md
+++ b/draft-ietf-openpgp-pqc.md
@@ -735,14 +735,8 @@ The algorithm-specific v6 signature parameters for ML-DSA + EdDSA signatures con
 
  - A fixed-length octet string of the ML-DSA signature value, whose length depends on the algorithm ID as specified in {{tab-mldsa-artifacts}}.
 
-A composite ML-DSA + EdDSA signature MUST use a hash algorithm whose digest size meets or exceeds the minimum digest size specified for the signature algorithm in {{tab-min-mldsa-eddsa-digest-size}}.
+A composite ML-DSA + EdDSA signature MUST use a hash algorithm with a digest size of at least 256 bits.
 A verifying implementation MUST reject any composite ML-DSA + EdDSA signature that uses a hash algorithm with a smaller digest size.
-
-{: title="Minimum hash algorithm digest size for composite ML-DSA + EdDSA signatures in bits" #tab-min-mldsa-eddsa-digest-size}
-ID | Algorithm         | Minimum digest size
-:--|:------------------|--------------------
-30 | ML-DSA-65+Ed25519 | 384
-31 | ML-DSA-87+Ed448   | 512
 
 ### Key Material Packets
 
@@ -801,15 +795,8 @@ The algorithm-specific part of a signature packet for an SLH-DSA algorithm code 
 
  - A fixed-length octet string of the SLH-DSA signature value, whose length depends on the algorithm ID in the format specified in {{slhdsa-artifact-lengths}}.
 
-An SLH-DSA signature MUST use a hash algorithm whose digest size meets or exceeds the minimum digest size specified for the signature algorithm in {{tab-min-slhdsa-digest-size}}.
+An SLH-DSA signature MUST use a hash algorithm with a digest size of at least 256 bits.
 A verifying implementation MUST reject any SLH-DSA signature that uses a hash algorithm with a smaller digest size.
-
-{: title="Minimum hash algorithm digest size for SLH-DSA signatures in bits" #tab-min-slhdsa-digest-size}
-ID | Algorithm           | Minimum digest size
-:--|:--------------------| ------------------
-32 | SLH-DSA-SHAKE-128s  | 256
-33 | SLH-DSA-SHAKE-128f  | 256
-34 | SLH-DSA-SHAKE-256s  | 512
 
 ### Key Material Packets
 
@@ -903,6 +890,14 @@ The algorithm ID identifies unequivocally the algorithm, the parameters for its 
 
 This specification makes use of the default "hedged" variants of ML-DSA and SLH-DSA, which mix fresh randomness into the respective signature-generation algorithm's internal hashing step.
 This has the advantage of an enhanced side-channel resistance of the signature operations according to  {{FIPS-204}} and {{FIPS-205}}.
+
+## Minimum digest size for PQ(/T)-signatures
+
+This specification requires that all PQ(/T) signatures defined in this document are made in combination with a hash algorithm of at least 256 bits digest size.
+The relevant security property is preimage resistance, since all signature algorithms defined in this document require signature packets of version 6 or higher, which include a random salt value.
+Therefore, a hash algorithm with 256 bits digest size is sufficient to match the targeted security level of all PQ(/T) algorithms defined in this document.
+Note that the minimum hash algorithm digest size requirement is different for signature schemes that are defined in [RFC9580], where signature algorithms are also allowed to be used with non-salted v4 signatures.
+In such cases, the relevant security property is collision resistance.
 
 ## Symmetric Algorithms for SEIPD Packets
 

--- a/draft-ietf-openpgp-pqc.md
+++ b/draft-ietf-openpgp-pqc.md
@@ -741,7 +741,7 @@ A verifying implementation MUST reject any composite ML-DSA + EdDSA signature th
 {: title="Minimum hash algorithm digest size for composite ML-DSA + EdDSA signatures in bits" #tab-min-mldsa-eddsa-digest-size}
 Signature algorithm | Minimum digest size
 :-------------------| ------------------
-ML-DSA-65+Ed25519   | 256
+ML-DSA-65+Ed25519   | 384
 ML-DSA-87+Ed448     | 512
 
 ### Key Material Packets

--- a/draft-ietf-openpgp-pqc.md
+++ b/draft-ietf-openpgp-pqc.md
@@ -735,6 +735,15 @@ The algorithm-specific v6 signature parameters for ML-DSA + EdDSA signatures con
 
  - A fixed-length octet string of the ML-DSA signature value, whose length depends on the algorithm ID as specified in {{tab-mldsa-artifacts}}.
 
+A composite ML-DSA + EdDSA signature MUST use a hash algorithm whose digest size meets or exceeds the minimum digest size specified for the signature algorithm in {{tab-min-mldsa-eddsa-digest-size}}.
+A verifying implementation MUST reject any composite ML-DSA + EdDSA signature that uses a hash algorithm with a smaller digest size.
+
+{: title="Minimum hash algorithm digest size for composite ML-DSA + EdDSA signatures in bits" #tab-min-mldsa-eddsa-digest-size}
+Signature algorithm | Minimum digest size
+:-------------------| ------------------
+ML-DSA-65+Ed25519   | 256
+ML-DSA-87+Ed448     | 512
+
 ### Key Material Packets
 
 The composite ML-DSA + EdDSA schemes MUST be used only with v6 keys, as defined in [RFC9580], or newer versions defined by updates of that document.
@@ -791,6 +800,16 @@ The SLH-DSA algorithms MUST be used only with v6 signatures, as defined in [[RFC
 The algorithm-specific part of a signature packet for an SLH-DSA algorithm code point consists of:
 
  - A fixed-length octet string of the SLH-DSA signature value, whose length depends on the algorithm ID in the format specified in {{slhdsa-artifact-lengths}}.
+
+An SLH-DSA signature MUST use a hash algorithm whose digest size meets or exceeds the minimum digest size specified for the signature algorithm in {{tab-min-slhdsa-digest-size}}.
+A verifying implementation MUST reject any SLH-DSA signature that uses a hash algorithm with a smaller digest size.
+
+{: title="Minimum hash algorithm digest size for SLH-DSA signatures in bits" #tab-min-slhdsa-digest-size}
+Signature algorithm | Minimum digest size
+:-------------------| ------------------
+SLH-DSA-SHAKE-128s  | 256
+SLH-DSA-SHAKE-128f  | 256
+SLH-DSA-SHAKE-256s  | 512
 
 ### Key Material Packets
 
@@ -1033,6 +1052,9 @@ ID     | Algorithm           | Public Key Format                                
 - Removed subkey semantics related guidance
 - Updated test vectors
 - Added non-normative algorithm explanation
+
+## draft-ietf-openpgp-pqc-10
+- Specified minumum requirements for signature digest sizes.
 
 # Contributors
 

--- a/draft-ietf-openpgp-pqc.md
+++ b/draft-ietf-openpgp-pqc.md
@@ -1045,13 +1045,13 @@ ID     | Algorithm           | Public Key Format                                
 ## draft-ietf-openpgp-pqc-08
 - Assigned code points 35 and 36 for ML-KEM + ECDH algorithms.
 - Removed hash binding for ML-DSA + EdDSA and SLH-DSA algorithms.
-- Allowed usage of ML-KEM-768 + X25519 with v4 keys
-- Aligned KEM combiner to X-Wing and switched to suffix-free encoding of the domain separator
+- Allowed usage of ML-KEM-768 + X25519 with v4 keys.
+- Aligned KEM combiner to X-Wing and switched to suffix-free encoding of the domain separator.
 
 ## draft-ietf-openpgp-pqc-09
-- Removed subkey semantics related guidance
-- Updated test vectors
-- Added non-normative algorithm explanation
+- Removed subkey semantics related guidance.
+- Updated test vectors.
+- Added non-normative algorithm explanation.
 
 ## draft-ietf-openpgp-pqc-10
 - Specified minumum requirements for signature digest sizes.

--- a/draft-ietf-openpgp-pqc.md
+++ b/draft-ietf-openpgp-pqc.md
@@ -894,7 +894,7 @@ This has the advantage of an enhanced side-channel resistance of the signature o
 ## Minimum digest size for PQ(/T)-signatures
 
 This specification requires that all PQ(/T) signatures defined in this document are made on message digests computed with a hash algorithm with at least 256 bits of digest size.
-Since all signature algorithms defined in this document require version 6 (and newer) signature packets, which currently include a leading random salt value in the hashed data, the required property is not collision but (2nd) preimage resistance.
+Since all signature algorithms defined in this document require version 6 (or newer) signature packets, which currently include a leading random salt value in the hashed data, the required property is not collision but (2nd) preimage resistance.
 Therefore, a hash algorithm with a digest size of at least 256 bits is sufficient to match the targeted security levels of all PQ(/T) algorithms defined in this document.
 
 ## Symmetric Algorithms for SEIPD Packets

--- a/draft-ietf-openpgp-pqc.md
+++ b/draft-ietf-openpgp-pqc.md
@@ -894,7 +894,7 @@ This has the advantage of an enhanced side-channel resistance of the signature o
 ## Minimum digest size for PQ(/T)-signatures
 
 This specification requires that all PQ(/T) signatures defined in this document are made on message digests computed with a hash algorithm with at least 256 bits of digest size.
-The relevant security property is preimage resistance, since all signature algorithms defined in this document require signature packets of version 6 or higher, which currently include a random salt prefix.
+Since all signature algorithms defined in this document require signature packets of version 6 or higher, which currently include a leading random salt value in the hashed data, hash-collision attacks do not apply to the signature schemes defined in this specification.
 Therefore, a hash algorithm with a digest size of 256 bits is sufficient to match the targeted security level of all PQ(/T) algorithms defined in this document, as it achieves a preimage and second preimage security of 256 bits.
 Note that the minimum hash algorithm digest size requirement is different for signature schemes that are defined in [RFC9580], where signature algorithms are also allowed to be used with non-salted v4 signatures.
 In such cases, the relevant security property is collision resistance.

--- a/draft-ietf-openpgp-pqc.md
+++ b/draft-ietf-openpgp-pqc.md
@@ -895,7 +895,7 @@ This has the advantage of an enhanced side-channel resistance of the signature o
 
 This specification requires that all PQ(/T) signatures defined in this document are made on message digests computed with a hash algorithm with at least 256 bits of digest size.
 The relevant security property is preimage resistance, since all signature algorithms defined in this document require signature packets of version 6 or higher, which currently include a random salt prefix.
-Therefore, a hash algorithm with 256 bits digest size is sufficient to match the targeted security level of all PQ(/T) algorithms defined in this document.
+Therefore, a hash algorithm with a digest size of 256 bits is sufficient to match the targeted security level of all PQ(/T) algorithms defined in this document, as it achieves a preimage and second preimage security of 256 bits.
 Note that the minimum hash algorithm digest size requirement is different for signature schemes that are defined in [RFC9580], where signature algorithms are also allowed to be used with non-salted v4 signatures.
 In such cases, the relevant security property is collision resistance.
 

--- a/draft-ietf-openpgp-pqc.md
+++ b/draft-ietf-openpgp-pqc.md
@@ -896,7 +896,6 @@ This has the advantage of an enhanced side-channel resistance of the signature o
 This specification requires that all PQ(/T) signatures defined in this document are made on message digests computed with a hash algorithm with at least 256 bits of digest size.
 Since all signature algorithms defined in this document require signature packets of version 6 or higher, which currently include a leading random salt value in the hashed data, hash-collision attacks do not apply to the signature schemes defined in this specification.
 Therefore, a hash algorithm with a digest size of 256 bits is sufficient to match the targeted security level of all PQ(/T) algorithms defined in this document, as it achieves a preimage and second preimage security of 256 bits.
-Note that the minimum hash algorithm digest size requirement is different for signature schemes that are defined in [RFC9580], where signature algorithms are also allowed to be used with non-salted v4 signatures.
 In such cases, the relevant security property is collision resistance.
 
 ## Symmetric Algorithms for SEIPD Packets

--- a/draft-ietf-openpgp-pqc.md
+++ b/draft-ietf-openpgp-pqc.md
@@ -1047,7 +1047,8 @@ ID     | Algorithm           | Public Key Format                                
 - Added non-normative algorithm explanation.
 
 ## draft-ietf-openpgp-pqc-10
-- Specified minumum requirements for signature digest sizes.
+- Specified minimum requirements for signature message digest sizes.
+- Added security considerations for signature message digest sizes.
 
 # Contributors
 


### PR DESCRIPTION
restrict hash algorithms for PQC signature algorithms similar to what RFC 9580 specifies, based on Daniel Huigen's suggestion in https://mailarchive.ietf.org/arch/msg/openpgp/r0C-dXz35BKx5rDsznt4rGcS6pM/