### PR TITLE
Cleanup ecdhPublicKey in ECDH-KEM.Decaps()

### DIFF
--- a/draft-ietf-openpgp-pqc.md
+++ b/draft-ietf-openpgp-pqc.md
@@ -593,7 +593,7 @@ The procedure to perform public-key decryption with an ML-KEM + ECDH composite s
 
  6. Parse `ecdhCipherText`, `mlkemCipherText`, and `C` from `encryptedKey` encoded as `ecdhCipherText || mlkemCipherText || len(C,symAlgId) (|| symAlgId) || C` as specified in {{ecc-mlkem-pkesk}}, where `symAlgId` is present only in the case of a v3 PKESK.
 
- 7. Compute `(ecdhKeyShare) = ECDH-KEM.Decaps(ecdhCipherText, ecdhSecretKey)`
+ 7. Compute `(ecdhKeyShare) = ECDH-KEM.Decaps(ecdhSecretKey, ecdhCipherText)`
 
  8. Compute `(mlkemKeyShare) = ML-KEM.Decaps(mlkemCipherText, mlkemSecretKey)`
 


### PR DESCRIPTION
@dkg Nice catch!

This is a leftover from our previous Cramer-Shoup IND-CCA2 conversion which was present up to version 6 of the draft (see https://datatracker.ietf.org/doc/html/draft-ietf-openpgp-pqc-06#name-ecdh-kems).

Now removed from `ECDH-KEM.Decaps()` in sections "ECDH KEMs" and "Decryption Procedure" (subsection of "Composite Encryption Schemes with ML-KEM").