### PR TITLE
Normalize text in Key Generation Procedure sections

### DIFF
--- a/draft-ietf-openpgp-pqc.md
+++ b/draft-ietf-openpgp-pqc.md
@@ -699,7 +699,7 @@ Algorithm ID reference | ML-DSA    | Public key | Secret key | Signature value
 
 The implementation MUST generate the ML-DSA and the EdDSA component keys independently.
 ML-DSA key generation follows the specification in [FIPS-204], and the artifacts are encoded as fixed-length octet strings whose sizes are listed in {{mldsa-signature}}.
-EdDSA key generation follows the specification in {{RFC7748}}, and the artifacts are encoded as fixed-length octet strings whose sizes are listed in {{eddsa-signature}}.
+EdDSA key generation follows the specification in {{RFC8032}}, and the artifacts are encoded as fixed-length octet strings whose sizes are listed in {{eddsa-signature}}.
 
 ### Signature Generation
 

--- a/draft-ietf-openpgp-pqc.md
+++ b/draft-ietf-openpgp-pqc.md
@@ -548,8 +548,8 @@ Here `len(domSep)` is the single octet with the value equal to the octet-length 
 ### Key generation procedure {#ecc-mlkem-generation}
 
 The implementation MUST generate the ML-KEM and the ECDH component keys independently.
-ML-KEM key generation follows the specification [FIPS-203] and the artifacts are encoded as fixed-length octet strings as defined in {{mlkem-ops}}.
-For ECDH this is done following the relative specification in {{RFC7748}}, and encoding the outputs as fixed-length octet strings in the format specified in {{tab-ecdh-cfrg-artifacts}}.
+ML-KEM key generation follows the specification in [FIPS-203], and the artifacts are encoded as fixed-length octet strings whose sizes are listed in {{mlkem-ops}}.
+ECDH key generation follows the specification in {{RFC7748}}, and the artifacts are encoded as fixed-length octet strings whose sizes are listed in {{tab-ecdh-cfrg-artifacts}}.
 
 ### Encryption procedure {#ecc-mlkem-encryption}
 
@@ -698,8 +698,8 @@ Algorithm ID reference | ML-DSA    | Public key | Secret key | Signature value
 ### Key generation procedure {#ecc-mldsa-generation}
 
 The implementation MUST generate the ML-DSA and the EdDSA component keys independently.
-ML-DSA key generation follows the specification [FIPS-204] and the artifacts are encoded as fixed-length octet strings as defined in {{mldsa-signature}}.
-For EdDSA this is done following the relative specification in {{RFC7748}}, and encoding the artifacts as specified in {{eddsa-signature}} as fixed-length octet strings.
+ML-DSA key generation follows the specification in [FIPS-204], and the artifacts are encoded as fixed-length octet strings whose sizes are listed in {{mldsa-signature}}.
+EdDSA key generation follows the specification in {{RFC7748}}, and the artifacts are encoded as fixed-length octet strings whose sizes are listed in {{eddsa-signature}}.
 
 ### Signature Generation
 
@@ -775,7 +775,7 @@ Algorithm ID reference   |  SLH-DSA public key | SLH-DSA secret key | SLH-DSA si
 
 ### Key generation
 
-SLH-DSA key generation is performed via the algorithm `SLH-DSA.KeyGen` as specified in {{FIPS-205}}, and the artifacts are encoded as fixed-length octet strings as defined in {{slhdsa}}.
+SLH-DSA key generation is performed via the algorithm `SLH-DSA.KeyGen` as specified in {{FIPS-205}}, and the artifacts are encoded as fixed-length octet strings whose sizes are listed in {{slhdsa}}.
 
 ### Signature Generation
 


### PR DESCRIPTION
It's not clear why the ML-* key generation sentences were sigificantly different from the ECC key generation sentences.

It was also not clear to me what "the relative specification" meant, so i've dropped that term.

The sections referenced don't seem to actually "specify formats", rather they describe the sizes of the objects, so i've adjusted that text too.