### PR TITLE
Indicate that this updates RFC 9580

### DIFF
--- a/draft-ietf-openpgp-pqc.md
+++ b/draft-ietf-openpgp-pqc.md
@@ -2,6 +2,7 @@
 title: "Post-Quantum Cryptography in OpenPGP"
 abbrev: "PQC in OpenPGP"
 category: info
+updates: 9580
 
 docname: draft-ietf-openpgp-pqc-latest
 submissiontype: IETF


### PR DESCRIPTION
I think it's fair to say that this updates 9580 just like 5581 updated 4880.

And, this changef will make it so that anyone looking at RFC 9580 will be pointed toward this document as well by the datatracker.