### PR TITLE
Move from informational to standards-track

### DIFF
--- a/draft-ietf-openpgp-pqc.md
+++ b/draft-ietf-openpgp-pqc.md
@@ -1,7 +1,7 @@
 ---
 title: "Post-Quantum Cryptography in OpenPGP"
 abbrev: "PQC in OpenPGP"
-category: info
+category: std
 updates: 9580
 
 docname: draft-ietf-openpgp-pqc-latest


### PR DESCRIPTION
RFC 9580 (OpenPGP) is marked as a Proposed Standard, as was RFC 4880 (OpenPGP) and RFC 6637 (ECC in OpenPGP).

By contrast, RFC 5581 (Camellia in OpenPGP) is marked informational.

https://www.rfc-editor.org/rfc/rfc2026.html#section-4.1 says:

   A Proposed Standard specification is generally stable, has resolved
   known design choices, is believed to be well-understood, has received
   significant community review, and appears to enjoy enough community
   interest to be considered valuable.  However, further experience
   might result in a change or even retraction of the specification
   before it advances.

while https://www.rfc-editor.org/rfc/rfc2026.html#section-4.2.2 says:

   An "Informational" specification is published for the general
   information of the Internet community, and does not represent an
   Internet community consensus or recommendation.  The Informational
   designation is intended to provide for the timely publication of a
   very broad range of responsible informational documents from many
   sources, subject only to editorial considerations and to verification
   that there has been adequate coordination with the standards process
   (see section 4.2.3).

I recommend marking this as standards-track, and indicating that its aimed at "Proposed Standard".