### PR TITLE
Handle update tag/info

### DIFF
--- a/draft-ietf-openpgp-pqc.md
+++ b/draft-ietf-openpgp-pqc.md
@@ -2,7 +2,6 @@
 title: "Post-Quantum Cryptography in OpenPGP"
 abbrev: "PQC in OpenPGP"
 category: std
-updates: 9580
 
 docname: draft-ietf-openpgp-pqc-latest
 submissiontype: IETF


### PR DESCRIPTION
I chose to remove the update tag for reasons of simplicity and since #253 adds a reference to RFC9580 to the abstract, so the setting and nature of this pqc spec should be clear.

Alternatively, I am open to add the tag back in again and add a clarifying sentence to the abstract.