### PR TITLE
RFC Editor idnits

### DIFF
--- a/draft-ietf-openpgp-pqc.md
+++ b/draft-ietf-openpgp-pqc.md
@@ -148,7 +148,7 @@ informative:
 
   CHHKM:
     target: https://eprint.iacr.org/2025/1397
-    title: Starfighters—On the General Applicability of X-Wing
+    title: Starfighters - On the General Applicability of X-Wing
     date: 2025
     seriesinfo: Cryptology {ePrint} Archive, Paper 2025/1397
     author:
@@ -156,11 +156,11 @@ informative:
         ins: D. Connolly
         name: Deirdre Connolly
       -
-        ins: K. Hövelmanns
-        name: Kathrin Hövelmanns
+        ins: K. Hoevelmanns
+        name: Kathrin Hoevelmanns
       -
-        ins: A. Hülsing
-        name: Andreas Hülsing
+        ins: A. Huelsing
+        name: Andreas Huelsing
       -
         ins: S. Kousidis
         name: Stavros Kousidis
@@ -221,7 +221,7 @@ informative:
 
 --- abstract
 
-This document defines a post-quantum public key algorithm extension for the OpenPGP protocol, extending [RFC9580].
+This document defines a post-quantum public key algorithm extension for the OpenPGP protocol, extending RFC9580.
 Given the generally assumed threat of a cryptographically relevant quantum computer, this extension provides a basis for long-term secure OpenPGP signatures and ciphertexts.
 Specifically, it defines composite public key encryption based on ML-KEM (formerly CRYSTALS-Kyber), composite public key signatures based on ML-DSA (formerly CRYSTALS-Dilithium), both in combination with elliptic curve cryptography, and SLH-DSA (formerly SPHINCS+) as a standalone public key signature scheme.
 
@@ -971,7 +971,7 @@ This specification introduces both ML-DSA + EdDSA as well as SLH-DSA as PQ(/T) s
 Generally, it can be said that ML-DSA + EdDSA provides a performance in terms of execution time requirements that is close to that of traditional ECC signature schemes.
 Regarding the size of signatures and public keys, though, ML-DSA has far greater requirements than traditional schemes like ECC-based or even RSA signature schemes.
 
-Implementers may want to offer SLH-DSA for applications where the weaker security assumptions of a hash-based signature scheme are required – namely only the 2nd preimage resistance of a hash function – and thus a potentially higher degree of trust in the long-term security of signatures is achieved.
+Implementers may want to offer SLH-DSA for applications where the weaker security assumptions of a hash-based signature scheme are required - namely only the 2nd preimage resistance of a hash function - and thus a potentially higher degree of trust in the long-term security of signatures is achieved.
 However, SLH-DSA has performance characteristics in terms of execution time of the signature generation as well as space requirements for the signature that are even greater than those of ML-DSA + EdDSA signature schemes.
 
 Pertaining to the execution time, the particularly costly operation in SLH-DSA is the signature generation.

--- a/draft-ietf-openpgp-pqc.md
+++ b/draft-ietf-openpgp-pqc.md
@@ -1194,7 +1194,7 @@ The hex-encoded output of `multiKeyCombine` is `5bf078bf7977109db6dead92d3578b62
 The hex-encoded session key is `94a3b8c9784463bb96b682cddf549adb23579b75bcb646f989d7cfe3e6e14435`.
 
 {: sourcecode-name="v6-eddsa-sample-message.asc"}
-~~~ application/pgp-keys
+~~~ application/pgp-encrypted
 {::include test-vectors/v6-eddsa-sample-message.asc}
 ~~~
 
@@ -1252,7 +1252,7 @@ The hex-encoded output of `multiKeyCombine` is `c1591d7511f9f0213bfd57cf316e5ec0
 The hex-encoded session key is `b4dc7197e1519822ca689da484643edf272934d98ae1974b5d88317a7a6a3c4f`.
 
 {: sourcecode-name="v4-eddsa-sample-message-v1.asc"}
-~~~ application/pgp-keys
+~~~ application/pgp-encrypted
 {::include test-vectors/v4-eddsa-sample-message-v1.asc}
 ~~~
 
@@ -1272,7 +1272,7 @@ The hex-encoded output of `multiKeyCombine` is `5c5652a690b55d1e9545fbd722f838cd
 The hex-encoded session key is `160867d96032b640208c1c92174d0270bb89189d72320711acd221bbea2a26b6`.
 
 {: sourcecode-name="v4-eddsa-sample-message-v2.asc"}
-~~~ application/pgp-keys
+~~~ application/pgp-encrypted
 {::include test-vectors/v4-eddsa-sample-message-v2.asc}
 ~~~
 
@@ -1333,7 +1333,7 @@ The hex-encoded output of `multiKeyCombine` is `a4904982f7caa9c9de690afd772d8bfe
 The hex-encoded session key is `adee68618b302d4bfd7ae3d432bc63a1c1ad7f5fd6e7fd7bdedbb0d0b14a5c9a`.
 
 {: sourcecode-name="v6-mldsa-65-sample-message.asc"}
-~~~ application/pgp-keys
+~~~ application/pgp-encrypted
 {::include test-vectors/v6-mldsa-65-sample-message.asc}
 ~~~
 
@@ -1344,7 +1344,7 @@ Here is a detached signature for the message "Testing\n" made by the secret key 
 - A v6 signature packet
 
 {: sourcecode-name="v6-mldsa-65-sample-signature.asc"}
-~~~ application/pgp-keys
+~~~ application/pgp-signature
 {::include test-vectors/v6-mldsa-65-sample-signature.asc}
 ~~~
 
@@ -1403,7 +1403,7 @@ The hex-encoded output of `multiKeyCombine` is `ef1e32906f67d39bc800d90cabb0033c
 The hex-encoded session key is `0588ce40b038aac353d1cf8c67a674b412985105794821013ef154f786c4d89d`.
 
 {: sourcecode-name="v6-mldsa-87-sample-message.asc"}
-~~~ application/pgp-keys
+~~~ application/pgp-encrypted
 {::include test-vectors/v6-mldsa-87-sample-message.asc}
 ~~~
 
@@ -1414,7 +1414,7 @@ Here is a detached signature for the message "Testing\n" made by the secret key 
 - A v6 signature packet
 
 {: sourcecode-name="v6-mldsa-87-sample-signature.asc"}
-~~~ application/pgp-keys
+~~~ application/pgp-signature
 {::include test-vectors/v6-mldsa-87-sample-signature.asc}
 ~~~
 
@@ -1473,7 +1473,7 @@ The hex-encoded output of `multiKeyCombine` is `ae8ab57801911c04c7b4c2a2f665cf8d
 The hex-encoded session key is `e87567cad8fee5738f92090feed009d8af95437fa664f94da98776d966bbbc52`.
 
 {: sourcecode-name="v6-slhdsa-128s-sample-message.asc"}
-~~~ application/pgp-keys
+~~~ application/pgp-encrypted
 {::include test-vectors/v6-slhdsa-128s-sample-message.asc}
 ~~~
 
@@ -1484,7 +1484,7 @@ Here is a detached signature for the message "Testing\n" made by the secret key 
 - A v6 signature packet
 
 {: sourcecode-name="v6-slhdsa-128s-sample-signature.asc"}
-~~~ application/pgp-keys
+~~~ application/pgp-signature
 {::include test-vectors/v6-slhdsa-128s-sample-signature.asc}
 ~~~
 
@@ -1534,7 +1534,7 @@ Here is a detached signature for the message "Testing\n" made by the secret key 
 - A v6 signature packet
 
 {: sourcecode-name="v6-slhdsa-128f-sample-signature.asc"}
-~~~ application/pgp-keys
+~~~ application/pgp-signature
 {::include test-vectors/v6-slhdsa-128f-sample-signature.asc}
 ~~~
 
@@ -1583,7 +1583,7 @@ Here is a detached signature for the message "Testing\n" made by the secret key 
 - A v6 signature packet
 
 {: sourcecode-name="v6-slhdsa-256s-sample-signature.asc"}
-~~~ application/pgp-keys
+~~~ application/pgp-signature
 {::include test-vectors/v6-slhdsa-256s-sample-signature.asc}
 ~~~
 


### PR DESCRIPTION
Removed some non-ASCII characters and tried to apply RFC 3156 consistently to the test vectors.