### PR TITLE
fix description of the placement of the v3 pkesk algorithm identifier

### DIFF
--- a/draft-ietf-openpgp-pqc.md
+++ b/draft-ietf-openpgp-pqc.md
@@ -627,7 +627,7 @@ The algorithm-specific fields consist of the output of the encryption procedure 
  - The wrapped session key represented as an octet string.
 
 Note that like in the case of the algorithms X25519 and X448 specified in [RFC9580], for the ML-KEM composite schemes, in the case of a v3 PKESK packet, the symmetric algorithm identifier is not encrypted.
-Instead, it is placed in plaintext after the `mlkemCipherText` and before the length octet preceding the wrapped session key.
+Instead, it is prepended to the wrapped session key in plaintext and its length is included in the preceding length field.
 In the case of v3 PKESK packets for ML-KEM composite schemes, the symmetric algorithm used MUST be AES-128, AES-192 or AES-256 (algorithm ID 7, 8 or 9).
 
 In the case of a v3 PKESK, a receiving implementation MUST check if the length of the unwrapped symmetric key matches the symmetric algorithm identifier, and abort if this is not the case.


### PR DESCRIPTION
Fixes the issue that Daniel Huigens raised on the mailing list https://mailarchive.ietf.org/arch/msg/openpgp/KEBlD6t9RcO3NIHb4S7y0ZwDbn0/